### PR TITLE
Limit maximum height of video player

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="uk-container-expand">
         <div data-shaka-player-container ref="container">
-            <video data-shaka-player :autoplay="shouldAutoPlay" style="width: 100%; height: 100%" ref="videoEl"></video>
+            <video data-shaka-player :autoplay="shouldAutoPlay" style="width: 100%; height: 100%; max-height: 75vh; min-height: 250px;" ref="videoEl"></video>
         </div>
     </div>
 </template>


### PR DESCRIPTION
Fixes #206.

This is just a quick fix solution that works on both vertical and horizontal displays. Ideally, there would be different layouts for different viewport sizes (both width and height).

I think the margin around the player controls, at least the bottom one, need to be adjusted a little, especially when the viewport gets too small vertically.

CC @B0pol