### PR TITLE
Adjustments to WatchVideo.vue to be more responsive and more similar to Youtube's UI

### DIFF
--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -63,7 +63,7 @@
         <hr />
 
         <div uk-grid>
-            <div class="uk-width-4-5@xl uk-width-3-4@l uk-width-2-3" v-if="comments" ref="comments">
+            <div class="uk-width-4-5@xl uk-width-3-4@l uk-width-1" v-if="comments" ref="comments">
                 <div
                     class="uk-tile-default uk-align-left uk-width-expand"
                     :style="[{ background: backgroundColor }]"
@@ -100,7 +100,7 @@
                 </div>
             </div>
 
-            <div class="uk-width-1-5@xl uk-width-1-4@l uk-width-1-3" v-if="video">
+            <div class="uk-width-1-5@xl uk-width-1-4@l uk-width-1 uk-flex-last@l uk-flex-first" v-if="video">
                 <div
                     class="uk-tile-default uk-width-auto"
                     :style="[{ background: backgroundColor }]"


### PR DESCRIPTION
Comments are now displayed below the related videos, similar to youtube UI. Related videos and comments now take full width for smaller screen.

Before:
<img width="562" alt="Screen Shot 2021-07-18 at 10 41 29 AM" src="https://user-images.githubusercontent.com/7316699/126073427-f06c6db1-5a93-491b-b5e6-7c3364aee6ea.png">
After:
<img width="562" alt="Screen Shot 2021-07-18 at 10 42 01 AM" src="https://user-images.githubusercontent.com/7316699/126073434-1e4fd004-2f9e-4937-8098-8c3af9572509.png">
