### PR TITLE
Temporary fix for logo

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -6,7 +6,7 @@
     >
         <div class="uk-navbar-left">
             <router-link class="uk-navbar-item uk-logo uk-text-bold" :style="[{ colour: foregroundColor }]" to="/"
-                ><img alt="logo" src="/img/icons/logo.svg" height="32" width="32" />iped</router-link
+                ><img alt="logo" src="/img/icons/logo.svg" height="32" width="32" style="margin-bottom: 6px; margin-right: -13px" />iped</router-link
             >
         </div>
         <div class="uk-navbar-center uk-flex uk-visible@m">


### PR DESCRIPTION
You likely should settle on a font, and create an SVG/PNG that includes the "iped" along with the stylized "P", but for now this temporary measure will help it look more presentable

Before / After
<img width="116" alt="Screen Shot 2021-07-18 at 12 42 15 PM" src="https://user-images.githubusercontent.com/7316699/126077116-cb5d42e9-d069-4ec6-b58e-b593d7c4aa6c.png">
<img width="98" alt="Screen Shot 2021-07-18 at 12 41 23 PM" src="https://user-images.githubusercontent.com/7316699/126077120-b41f77b2-5dd7-4ba1-acaa-f111f6736f32.png">
