### PR TITLE
Show video duration in thumbnail (#269)

### DIFF
--- a/src/components/FeedPage.vue
+++ b/src/components/FeedPage.vue
@@ -18,7 +18,14 @@
         >
             <div class="uk-text-secondary" :style="[{ background: backgroundColor }]">
                 <router-link class="uk-text-emphasis" v-bind:to="'/watch?v=' + video.id">
-                    <img style="width: 100%" v-bind:src="video.thumbnail" alt="thumbnail" loading="lazy" />
+                    <div class="uk-position-relative">
+                        <img style="width: 100%" v-bind:src="video.thumbnail" alt="thumbnail" loading="lazy" />
+                        <span 
+                            v-if="video.duration"
+                            class="uk-label uk-border-rounded uk-position-absolute video-duration" 
+                            style="bottom: 5px; right: 5px; background: rgba(0, 0, 0, .75); color: white; padding: 0 5px;"
+                            >{{ timeFormat(video.duration) }}</span>
+                    </div>
                     <p>{{ video.title }}</p>
                 </router-link>
 
@@ -42,10 +49,6 @@
                     </div>
                 </b>
                 <div class="uk-align-right">
-                    <b class="uk-text-small">{{ timeFormat(video.duration) }}</b>
-
-                    <br />
-
                     <router-link :to="'/watch?v=' + video.id + '&listen=1'">
                         <font-awesome-icon icon="headphones"></font-awesome-icon>
                     </router-link>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -27,7 +27,14 @@
         >
             <div class="uk-text-secondary">
                 <router-link class="uk-text-emphasis" v-bind:to="result.url">
-                    <img style="width: 100%" v-bind:src="result.thumbnail" loading="lazy" />
+                    <div class="uk-position-relative">
+                        <img style="width: 100%" v-bind:src="result.thumbnail" loading="lazy" />
+                        <span 
+                            v-if="result.duration"
+                            class="uk-label uk-border-rounded uk-position-absolute uk-dark" 
+                            style="bottom: 5px; right: 5px; opacity: .95;"
+                            >{{ timeFormat(result.duration) }}</span>
+                    </div>
                     <p>
                         {{ result.name }}&thinsp;<font-awesome-icon
                             v-if="result.verified"
@@ -44,9 +51,6 @@
                         ></font-awesome-icon>
                     </p>
                 </router-link>
-                <b v-if="result.duration" class="uk-text-small uk-align-right uk-text-align-right">
-                    {{ timeFormat(result.duration) }}
-                </b>
 
                 <b v-if="result.uploadDate">
                     {{ result.uploadDate }}

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -1,14 +1,21 @@
 <template>
     <div class="uk-text-secondary" :style="[{ background: backgroundColor }]">
         <router-link class="uk-text-emphasis" v-bind:to="video.url">
-            <img
-                :height="height"
-                :width="width"
-                style="width: 100%"
-                v-bind:src="video.thumbnail"
-                alt="thumbnail"
-                loading="lazy"
-            />
+            <div class="uk-position-relative">
+                <img
+                    :height="height"
+                    :width="width"
+                    style="width: 100%"
+                    v-bind:src="video.thumbnail"
+                    alt="thumbnail"
+                    loading="lazy"
+                />
+                <span 
+                    v-if="video.duration"
+                    class="uk-label uk-border-rounded uk-position-absolute uk-dark" 
+                    style="bottom: 5px; right: 5px; opacity: .95;"
+                    >{{ timeFormat(video.duration) }}</span>
+            </div>
             <p>{{ video.title }}</p>
         </router-link>
 
@@ -32,10 +39,6 @@
             </div>
         </b>
         <div class="uk-align-right">
-            <b class="uk-text-small">{{ timeFormat(video.duration) }}</b>
-
-            <br />
-
             <router-link :to="video.url + '&listen=1'">
                 <font-awesome-icon icon="headphones"></font-awesome-icon>
             </router-link>

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -12,8 +12,8 @@
                 />
                 <span 
                     v-if="video.duration"
-                    class="uk-label uk-border-rounded uk-position-absolute uk-dark" 
-                    style="bottom: 5px; right: 5px; opacity: .95;"
+                    class="uk-label uk-border-rounded uk-position-absolute video-duration" 
+                    style="bottom: 5px; right: 5px; background: rgba(0, 0, 0, .75); color: white; padding: 0 5px;"
                     >{{ timeFormat(video.duration) }}</span>
             </div>
             <p>{{ video.title }}</p>


### PR DESCRIPTION
Moved the video duration from the video metadata section to a label in the bottom right corner of the thumbnail. Fixes #269.