### PR TITLE
feat(hyperlinking): hyperlinking URLs in the channel descriptions

### DIFF
--- a/src/components/Channel.vue
+++ b/src/components/Channel.vue
@@ -4,7 +4,7 @@
     <div v-if="channel" v-show="!channel.error">
         <h1 class="uk-text-center"><img height="48" width="48" v-bind:src="channel.avatarUrl" />{{ channel.name }}</h1>
         <img v-if="channel.bannerUrl" v-bind:src="channel.bannerUrl" style="width: 100%" loading="lazy" />
-        <p style="white-space: pre-wrap">{{ channel.description }}</p>
+        <p style="white-space: pre-wrap"><span v-html="urlify(channel.description)"></span></p>
 
         <button
             v-if="authenticated"

--- a/src/components/Channel.vue
+++ b/src/components/Channel.vue
@@ -4,7 +4,7 @@
     <div v-if="channel" v-show="!channel.error">
         <h1 class="uk-text-center"><img height="48" width="48" v-bind:src="channel.avatarUrl" />{{ channel.name }}</h1>
         <img v-if="channel.bannerUrl" v-bind:src="channel.bannerUrl" style="width: 100%" loading="lazy" />
-        <p style="white-space: pre-wrap"><span v-html="urlify(channel.description)"></span></p>
+        <p style="white-space: pre-wrap"><span v-html="purifyHTML(urlify(channel.description))"></span></p>
 
         <button
             v-if="authenticated"

--- a/src/main.js
+++ b/src/main.js
@@ -158,6 +158,16 @@ const mixin = {
         timeAgo(time) {
             return timeAgo.format(time);
         },
+        urlify(string) {
+            const regex = /(((https?:\/\/)|(www\.))[^\s]+)/g;
+            if (!string) return '';
+            return string.replace(regex, (url) => {
+                if (!url.match('^https?:\\/\\/')) { // If URL does not have http(s), we're adding it manually.
+                    return `<a class="uk-button uk-button-text" href="http://${url}" target="_blank">${url}</a>`
+                }
+                return `<a class="uk-button uk-button-text" href="${url}" target="_blank">${url}</a>`
+            })
+        }
     },
     computed: {
         backgroundColor() {

--- a/src/main.js
+++ b/src/main.js
@@ -162,9 +162,6 @@ const mixin = {
             const regex = /(((https?:\/\/)|(www\.))[^\s]+)/g;
             if (!string) return '';
             return string.replace(regex, (url) => {
-                if (!url.match('^https?:\\/\\/')) { // If URL does not have http(s), we're adding it manually.
-                    return `<a class="uk-button uk-button-text" href="http://${url}" target="_blank">${url}</a>`
-                }
                 return `<a class="uk-button uk-button-text" href="${url}" target="_blank">${url}</a>`
             })
         }


### PR DESCRIPTION
Fix for #7.
Now with this fix, URLs on channel descriptions are clickable as hyperlinks.

**Note**: Regex for URLs detection is not quite a complete regex. As you know there are complex and more completed regex out there. If you prefer to use a more confident regex, let me know.

Example channel: [here](https://piped.kavin.rocks/channel/UCKlOmM_eB0nzTNiDFZibSSA)

Comments are welcome.