### PR TITLE
Fix overflowing titles

### DIFF
--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -17,7 +17,7 @@
                     >{{ timeFormat(video.duration) }}</span
                 >
             </div>
-            <p>{{ video.title }}</p>
+            <p class="uk-text-break">{{ video.title }}</p>
         </router-link>
 
         <div :class="{ 'uk-align-left': !(video.views >= 0 || video.uploadedDate) }">


### PR DESCRIPTION
Added class `uk-text-break` to video title to stop it from overflowing. See pictures.

Before:
![before](https://user-images.githubusercontent.com/10532336/127049596-f9af1fd7-1ee7-4b22-b12e-0b90b55a8982.PNG)

After:
![after](https://user-images.githubusercontent.com/10532336/127049609-9a454e99-efb7-453e-8ef5-0061c64e6b26.PNG)

This fixes #306.