### PR TITLE
Fix overflowing title when watching video

### DIFF
--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -17,7 +17,7 @@
                     >{{ timeFormat(video.duration) }}</span
                 >
             </div>
-            <p>{{ video.title }}</p>
+            <p class="uk-text-break">{{ video.title }}</p>
         </router-link>
 
         <div :class="{ 'uk-align-left': !(video.views >= 0 || video.uploadedDate) }">

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -10,7 +10,7 @@
                 :selectedAutoPlay="selectedAutoPlay"
                 :selectedAutoLoop="selectedAutoLoop"
             />
-            <div class="uk-text-bold uk-margin-small-top uk-text-large uk-text-emphasis">{{ video.title }}</div>
+            <div class="uk-text-bold uk-margin-small-top uk-text-large uk-text-emphasis uk-text-break">{{ video.title }}</div>
 
             <div class="uk-flex uk-flex-middle">
                 <div class="uk-margin-small-right">{{ addCommas(video.views) }} views</div>


### PR DESCRIPTION
Add the same `uk-text-break` class to video title in [WatchVideo.vue](https://github.com/TeamPiped/Piped/blob/master/src/components/WatchVideo.vue), [as commented by ajkblue](https://github.com/TeamPiped/Piped/pull/318#issuecomment-887102042).