### PR TITLE
10 second scroll on double tap player

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -241,6 +241,27 @@ export default {
         },
     },
     activated() {
+        const videoEl = this.$refs.videoEl;
+        var lastClick = new Date();
+        document.addEventListener("click", function(event) {
+            var t = event.target;
+            while (t && t !== this) {
+                if (t.matches(".shaka-mobile.shaka-video-container")) {
+                    if ((new Date() - lastClick) < 400) {
+                        var videoMiddlePX = videoEl.offsetWidth / 2;
+                        if (videoMiddlePX < event.layerX) {
+                            videoEl.currentTime = videoEl.currentTime + 10;
+                        } else {
+                            videoEl.currentTime = videoEl.currentTime - 10;
+                        }
+                        videoEl.play();
+                    }
+                    lastClick = new Date();
+                }
+                t = t.parentNode;
+            }
+        });
+
         import("hotkeys-js")
             .then(mod => mod.default)
             .then(hotkeys => {

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -179,6 +179,7 @@ export default {
                 this.ui = new shaka.ui.Overlay(localPlayer, this.$refs.container, videoEl);
 
                 const config = {
+                    doubleClickForFullscreen: false,
                     overflowMenuButtons: ["quality", "captions", "picture_in_picture", "playback_rate", "airplay"],
                     seekBarColors: {
                         base: "rgba(255, 255, 255, 0.3)",


### PR DESCRIPTION
This comes at the cost of double tap to fullscreen, i guess we could override the the shaka player logic and make and edge case for mobile devices, like here:
https://github.com/google/shaka-player/commit/cf5d893d6ff3dc43da89131570debc30348a1437