### PR TITLE
Changed LBRY references to Odysee references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ By using Piped, you can freely watch and listen to content freely without the fe
 -   [x] Login
 -   [x] Feeds
 -   [x] Integration with SponsorBlock
--   [x] Integration with LBRY
+-   [x] Integration with Odysee
 -   [x] 4K support
 -   [x] No connections to Google's servers
 -   [x] Playing just audio

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -51,7 +51,7 @@
                     class="uk-margin-small-left uk-button uk-button-small"
                     style="background: #222"
                 >
-                    <b>Watch on LBRY</b>
+                    <b>Watch on Odysee</b>
                 </a>
             </div>
 


### PR DESCRIPTION
Odysee is not LBRY. LBRY is a blockchain and P2P network for hosting
content without censorship, Odysee is a centralised site that serves
content from LBRY.
See lbry://@lbry:3f/theendoflbrytv:0 or https://odysee.com/@lbry:3f/theendoflbrytv:0 for more details.

Another thing that might be widespread in the future is redirecting 'lbry://' links to a native LBRY application. If that happens I think it would be worth adding a real 'Watch on LBRY' button with such a link. I may do that in the future.