### PR TITLE
Indicate video is streaming from lbry

### DIFF
--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -53,7 +53,9 @@
                 >
                     <b>{{ $t("player.watch_on") }} LBRY</b>
                 </a>
+                
             </div>
+            <b v-if="video.lbryId">Video streaming from LBRY</b>
 
             <div class="uk-flex uk-flex-middle uk-margin-small-top">
                 <img :src="video.uploaderAvatar" loading="lazy" class="uk-border-circle" />


### PR DESCRIPTION
To indicate that the video is being streamed from LBRY
One big problem
 - if LBRY streaming is disabled, the string appears. I don't know how to fix this.
Screenshot
![image](https://user-images.githubusercontent.com/65799568/132169698-569d7dd2-ada8-4b3e-8dc9-9235d2cb1793.png)
