### PR TITLE
Fix safari fullscreen

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -29,6 +29,11 @@
     background-color: rgba(8, 8, 8, 0.75) !important;
     color: white !important;
 }
+
+.shaka-video-container:-webkit-full-screen {
+    max-height: none !important;
+}
+
 </style>
 
 <script>


### PR DESCRIPTION
Closes #394

The issue was the `max-height: 75vh` set when `isEmbed` is true is not overridden by Safari in fullscreen automatically.

Contribution for Hacktoberfest :)