### PR TITLE
Refactor template code to increase readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "serve": "vite",
         "build": "vite build",
         "preview": "vite preview",
-        "lint": "eslint --fix --color --ignore-path .gitignore ."
+        "lint": "eslint --fix --color --ignore-path .gitignore --ext .js,.vue ."
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "scripts": {
         "serve": "vite",
         "build": "vite build",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "lint": "eslint --fix --color --ignore-path .gitignore ."
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
@@ -31,10 +32,12 @@
         "@vue/compiler-sfc": "3.2.26",
         "babel-eslint": "^10.1.0",
         "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-vue": "^7.20.0",
         "prettier": "^2.5.1",
         "vite": "^2.7.9",
+        "vite-plugin-eslint": "^1.3.0",
         "vite-plugin-pwa": "^0.11.12",
         "vite-plugin-windicss": "^1.6.1"
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@
             </a>
             <a class="ml-2" href="https://github.com/TeamPiped/Piped#donations">
                 <font-awesome-icon :icon="['fab', 'bitcoin']"></font-awesome-icon>
-                {{ $t("actions.donations") }}
+                <span v-text="$t('actions.donations')" />
             </a>
         </footer>
     </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,10 +9,10 @@
 
         <footer class="text-center">
             <a aria-label="GitHub" href="https://github.com/TeamPiped/Piped">
-                <font-awesome-icon :icon="['fab', 'github']"></font-awesome-icon>
+                <font-awesome-icon :icon="['fab', 'github']" />
             </a>
             <a class="ml-2" href="https://github.com/TeamPiped/Piped#donations">
-                <font-awesome-icon :icon="['fab', 'bitcoin']"></font-awesome-icon>
+                <font-awesome-icon :icon="['fab', 'bitcoin']" />
                 <span v-text="$t('actions.donations')" />
             </a>
         </footer>

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,7 @@ export default {
         if (this.getPreferenceBoolean("watchHistory", false))
             if ("indexedDB" in window) {
                 const request = indexedDB.open("piped-db", 1);
-                request.onupgradeneeded = function() {
+                request.onupgradeneeded = function () {
                     const db = request.result;
                     console.log("Upgrading object store.");
                     if (!db.objectStoreNames.contains("watch_history")) {
@@ -56,7 +56,7 @@ export default {
 
         const App = this;
 
-        (async function() {
+        (async function () {
             const locale = App.getPreferenceString("hl", App.defaultLangage);
             if (locale !== App.TimeAgoConfig.locale) {
                 const localeTime = await import("javascript-time-ago/locale/" + locale + ".json").then(

--- a/src/components/Channel.vue
+++ b/src/components/Channel.vue
@@ -8,7 +8,9 @@
         </div>
         <img v-if="channel.bannerUrl" :src="channel.bannerUrl" class="w-full pb-1.5" loading="lazy" />
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <p style="white-space: pre-wrap"><span v-html="purifyHTML(urlify(channel.description))"></span></p>
+        <p style="white-space: pre-wrap">
+            <span v-html="purifyHTML(urlify(channel.description))" />
+        </p>
 
         <button
             v-if="authenticated"

--- a/src/components/Channel.vue
+++ b/src/components/Channel.vue
@@ -4,15 +4,18 @@
     <div v-if="channel" v-show="!channel.error">
         <div class="flex justify-center place-items-center">
             <img height="48" width="48" class="rounded-full m-1" :src="channel.avatarUrl" />
-            <h1>{{ channel.name }}</h1>
+            <h1 v-text="channel.name" />
         </div>
         <img v-if="channel.bannerUrl" :src="channel.bannerUrl" class="w-full pb-1.5" loading="lazy" />
         <!-- eslint-disable-next-line vue/no-v-html -->
         <p style="white-space: pre-wrap"><span v-html="purifyHTML(urlify(channel.description))"></span></p>
 
-        <button v-if="authenticated" class="btn" @click="subscribeHandler">
-            {{ subscribed ? $t("actions.unsubscribe") : $t("actions.subscribe") }}
-        </button>
+        <button
+            v-if="authenticated"
+            class="btn"
+            @click="subscribeHandler"
+            v-text="$t(`actions.${subscribed ? 'unsubscribe' : 'subscribe'}`)"
+        />
 
         <hr />
 

--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -13,25 +13,23 @@
             <div class="comment-header">
                 <div v-if="comment.pinned" class="comment-pinned uk-text-meta">
                     <font-awesome-icon icon="thumbtack"></font-awesome-icon
-                    ><span class="ml-1.5">{{ $t("comment.pinned_by") }}</span>
-                    {{ uploader }}
+                    ><span class="ml-1.5" v-text="$t('comment.pinned_by')" />
+                    <span v-text="uploader" />
                 </div>
 
                 <div class="comment-author">
-                    <router-link class="font-bold uk-text-small" :to="comment.commentorUrl">
-                        {{ comment.author }} </router-link
-                    ><font-awesome-icon class="ml-1.5" v-if="comment.verified" icon="check"></font-awesome-icon>
+                    <router-link
+                        class="font-bold uk-text-small"
+                        :to="comment.commentorUrl"
+                        v-text="comment.author"
+                    /><font-awesome-icon class="ml-1.5" v-if="comment.verified" icon="check"></font-awesome-icon>
                 </div>
-                <div class="comment-meta uk-text-meta uk-margin-small-bottom">
-                    {{ comment.commentedTime }}
-                </div>
+                <div class="comment-meta uk-text-meta uk-margin-small-bottom" v-text="comment.commentedTime" />
             </div>
-            <div class="whitespace-pre-wrap">
-                {{ comment.commentText }}
-            </div>
+            <div class="whitespace-pre-wrap" v-text="comment.commentText" />
             <div class="comment-footer uk-margin-small-top uk-text-meta">
                 <font-awesome-icon icon="thumbs-up"></font-awesome-icon>
-                <span class="ml-1">{{ numberFormat(comment.likeCount) }}</span>
+                <span class="ml-1" v-text="numberFormat(comment.likeCount)" />
                 <font-awesome-icon class="ml-1" v-if="comment.hearted" icon="heart"></font-awesome-icon>
             </div>
             <template v-if="comment.repliesPage && (!loadingReplies || !showingReplies)">

--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -12,25 +12,22 @@
         <div class="comment-content pl-2">
             <div class="comment-header">
                 <div v-if="comment.pinned" class="comment-pinned uk-text-meta">
-                    <font-awesome-icon icon="thumbtack"></font-awesome-icon
-                    ><span class="ml-1.5" v-text="$t('comment.pinned_by')" />
+                    <font-awesome-icon icon="thumbtack" />
+                    <span class="ml-1.5" v-text="$t('comment.pinned_by')" />
                     <span v-text="uploader" />
                 </div>
 
                 <div class="comment-author">
-                    <router-link
-                        class="font-bold uk-text-small"
-                        :to="comment.commentorUrl"
-                        v-text="comment.author"
-                    /><font-awesome-icon class="ml-1.5" v-if="comment.verified" icon="check"></font-awesome-icon>
+                    <router-link class="font-bold uk-text-small" :to="comment.commentorUrl" v-text="comment.author" />
+                    <font-awesome-icon class="ml-1.5" v-if="comment.verified" icon="check" />
                 </div>
                 <div class="comment-meta uk-text-meta uk-margin-small-bottom" v-text="comment.commentedTime" />
             </div>
             <div class="whitespace-pre-wrap" v-text="comment.commentText" />
             <div class="comment-footer uk-margin-small-top uk-text-meta">
-                <font-awesome-icon icon="thumbs-up"></font-awesome-icon>
+                <font-awesome-icon icon="thumbs-up" />
                 <span class="ml-1" v-text="numberFormat(comment.likeCount)" />
-                <font-awesome-icon class="ml-1" v-if="comment.hearted" icon="heart"></font-awesome-icon>
+                <font-awesome-icon class="ml-1" v-if="comment.hearted" icon="heart" />
             </div>
             <template v-if="comment.repliesPage && (!loadingReplies || !showingReplies)">
                 <div @click="loadReplies">

--- a/src/components/ErrorHandler.vue
+++ b/src/components/ErrorHandler.vue
@@ -1,6 +1,5 @@
 <template>
     <p v-text="message" />
-    >
     <button @click="toggleTrace" class="btn" v-text="$t('actions.show_more')" />
     <p ref="stacktrace" style="white-space: pre-wrap" hidden v-text="error" />
 </template>

--- a/src/components/ErrorHandler.vue
+++ b/src/components/ErrorHandler.vue
@@ -1,9 +1,8 @@
 <template>
-    <p>{{ message }}</p>
-    <button @click="toggleTrace" class="btn">
-        {{ $t("actions.show_more") }}
-    </button>
-    <p ref="stacktrace" style="white-space: pre-wrap" hidden>{{ error }}</p>
+    <p v-text="message" />
+    >
+    <button @click="toggleTrace" class="btn" v-text="$t('actions.show_more')" />
+    <p ref="stacktrace" style="white-space: pre-wrap" hidden v-text="error" />
 </template>
 
 <script>

--- a/src/components/FeedPage.vue
+++ b/src/components/FeedPage.vue
@@ -12,13 +12,7 @@
     </span>
 
     <span class="md:float-right">
-        <label for="ddlSortBy" v-text="$t('actions.sort_by')" />
-        <select id="ddlSortBy" v-model="selectedSort" class="select w-auto" @change="onChange()">
-            <option v-t="'actions.most_recent'" value="descending" />
-            <option v-t="'actions.least_recent'" value="ascending" />
-            <option v-t="'actions.channel_name_asc'" value="channel_ascending" />
-            <option v-t="'actions.channel_name_desc'" value="channel_descending" />
-        </select>
+        <Sorting by-key="uploaded" @apply="order => videos.sort(order)" />
     </span>
 
     <hr />
@@ -30,10 +24,12 @@
 
 <script>
 import VideoItem from "@/components/VideoItem.vue";
+import Sorting from "@/components/Sorting.vue";
 
 export default {
     components: {
         VideoItem,
+        Sorting,
     },
     data() {
         return {
@@ -41,7 +37,6 @@ export default {
             videoStep: 100,
             videosStore: [],
             videos: [],
-            selectedSort: "descending",
         };
     },
     computed: {
@@ -72,22 +67,6 @@ export default {
             return await this.fetchJson(this.apiUrl() + "/feed", {
                 authToken: this.getAuthToken(),
             });
-        },
-        onChange() {
-            switch (this.selectedSort) {
-                case "ascending":
-                    this.videos.sort((a, b) => a.uploaded - b.uploaded);
-                    break;
-                case "descending":
-                    this.videos.sort((a, b) => b.uploaded - a.uploaded);
-                    break;
-                case "channel_ascending":
-                    this.videos.sort((a, b) => a.uploaderName.localeCompare(b.uploaderName));
-                    break;
-                case "channel_descending":
-                    this.videos.sort((a, b) => b.uploaderName.localeCompare(a.uploaderName));
-                    break;
-            }
         },
         loadMoreVideos() {
             this.currentVideoCount = Math.min(this.currentVideoCount + this.videoStep, this.videosStore.length);

--- a/src/components/FeedPage.vue
+++ b/src/components/FeedPage.vue
@@ -10,7 +10,7 @@
     </span>
 
     <span class="md:float-right">
-        <label for="ddlSortBy">{{ $t("actions.sort_by") }}</label>
+        <label for="ddlSortBy" v-text="$t('actions.sort_by')" />
         <select id="ddlSortBy" v-model="selectedSort" class="select w-auto" @change="onChange()">
             <option v-t="'actions.most_recent'" value="descending" />
             <option v-t="'actions.least_recent'" value="ascending" />

--- a/src/components/FeedPage.vue
+++ b/src/components/FeedPage.vue
@@ -6,7 +6,9 @@
     </button>
 
     <span>
-        <a :href="getRssUrl"><font-awesome-icon icon="rss" style="padding-top: 0.2rem"></font-awesome-icon></a>
+        <a :href="getRssUrl">
+            <font-awesome-icon icon="rss" style="padding-top: 0.2rem" />
+        </a>
     </span>
 
     <span class="md:float-right">

--- a/src/components/HistoryPage.vue
+++ b/src/components/HistoryPage.vue
@@ -1,12 +1,12 @@
 <template>
-    <h1 class="font-bold text-center">{{ $t("titles.history") }}</h1>
+    <h1 class="font-bold text-center" v-text="$t('titles.history')" />
 
     <div style="text-align: left">
         <button class="btn" v-t="'actions.clear_history'" @click="clearHistory"></button>
     </div>
 
     <div style="text-align: right">
-        <label for="ddlSortBy">{{ $t("actions.sort_by") }}</label>
+        <label for="ddlSortBy" v-text="$t('actions.sort_by')" />
         <select id="ddlSortBy" v-model="selectedSort" class="select w-auto" @change="onChange()">
             <option v-t="'actions.most_recent'" value="descending" />
             <option v-t="'actions.least_recent'" value="ascending" />

--- a/src/components/HistoryPage.vue
+++ b/src/components/HistoryPage.vue
@@ -2,7 +2,7 @@
     <h1 class="font-bold text-center" v-text="$t('titles.history')" />
 
     <div style="text-align: left">
-        <button class="btn" v-t="'actions.clear_history'" @click="clearHistory"></button>
+        <button class="btn" v-t="'actions.clear_history'" @click="clearHistory" />
     </div>
 
     <div style="text-align: right">

--- a/src/components/HistoryPage.vue
+++ b/src/components/HistoryPage.vue
@@ -6,13 +6,7 @@
     </div>
 
     <div style="text-align: right">
-        <label for="ddlSortBy" v-text="$t('actions.sort_by')" />
-        <select id="ddlSortBy" v-model="selectedSort" class="select w-auto" @change="onChange()">
-            <option v-t="'actions.most_recent'" value="descending" />
-            <option v-t="'actions.least_recent'" value="ascending" />
-            <option v-t="'actions.channel_name_asc'" value="channel_ascending" />
-            <option v-t="'actions.channel_name_desc'" value="channel_descending" />
-        </select>
+        <Sorting by-key="watchedAt" @apply="order => videos.sort(order)" />
     </div>
 
     <hr />
@@ -26,15 +20,16 @@
 
 <script>
 import VideoItem from "@/components/VideoItem.vue";
+import Sorting from "@/components/Sorting.vue";
 
 export default {
     components: {
         VideoItem,
+        Sorting,
     },
     data() {
         return {
             videos: [],
-            selectedSort: "descending",
         };
     },
     mounted() {
@@ -67,22 +62,6 @@ export default {
         document.title = "Watch History - Piped";
     },
     methods: {
-        onChange() {
-            switch (this.selectedSort) {
-                case "ascending":
-                    this.videos.sort((a, b) => a.watchedAt - b.watchedAt);
-                    break;
-                case "descending":
-                    this.videos.sort((a, b) => b.watchedAt - a.watchedAt);
-                    break;
-                case "channel_ascending":
-                    this.videos.sort((a, b) => a.uploaderName.localeCompare(b.uploaderName));
-                    break;
-                case "channel_descending":
-                    this.videos.sort((a, b) => b.uploaderName.localeCompare(a.uploaderName));
-                    break;
-            }
-        },
         clearHistory() {
             if (window.db) {
                 var tx = window.db.transaction("watch_history", "readwrite");

--- a/src/components/ImportPage.vue
+++ b/src/components/ImportPage.vue
@@ -5,17 +5,17 @@
                 <input ref="fileSelector" type="file" @change="fileChange" />
             </div>
             <div class="uk-form-row">
-                <b>Selected Subscriptions: {{ selectedSubscriptions }}</b>
+                <strong>Selected Subscriptions: {{ selectedSubscriptions }}</strong>
             </div>
             <div class="uk-form-row">
-                <b>Override: <input v-model="override" class="uk-checkbox" type="checkbox"/></b>
+                <strong>Override: <input v-model="override" class="uk-checkbox" type="checkbox" /></strong>
             </div>
             <div class="uk-form-row">
                 <a class="uk-width-1-1 btn uk-button-large w-auto" @click="handleImport">Import</a>
             </div>
         </form>
         <br />
-        <b>Importing Subscriptions from YouTube</b>
+        <strong>Importing Subscriptions from YouTube</strong>
         <br />
         <div>
             Open
@@ -30,7 +30,7 @@
             Select and import the file above.
         </div>
         <br />
-        <b>Importing Subscriptions from Invidious</b>
+        <strong>Importing Subscriptions from Invidious</strong>
         <br />
         <div>
             Open
@@ -41,7 +41,7 @@
             Select and import the file above.
         </div>
         <br />
-        <b>Importing Subscriptions from NewPipe</b>
+        <strong>Importing Subscriptions from NewPipe</strong>
         <br />
         <div>
             Go to the Feed tab.

--- a/src/components/ImportPage.vue
+++ b/src/components/ImportPage.vue
@@ -5,7 +5,7 @@
                 <input ref="fileSelector" type="file" @change="fileChange" />
             </div>
             <div class="uk-form-row">
-                <strong>Selected Subscriptions: {{ selectedSubscriptions }}</strong>
+                <strong v-text="`Selected Subscriptions: ${selectedSubscriptions}`" />
             </div>
             <div class="uk-form-row">
                 <strong>Override: <input v-model="override" class="uk-checkbox" type="checkbox" /></strong>

--- a/src/components/LoginPage.vue
+++ b/src/components/LoginPage.vue
@@ -22,9 +22,7 @@
                 />
             </div>
             <div class="uk-form-row">
-                <a class="uk-width-1-1 uk-button uk-button-large w-auto" @click="login">
-                    {{ $t("titles.login") }}
-                </a>
+                <a class="uk-width-1-1 uk-button uk-button-large w-auto" @click="login" v-text="$t('titles.login')" />
             </div>
         </form>
     </div>

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -6,13 +6,7 @@
             style="width: 100%; height: 100%; background: #000"
             :style="!isEmbed ? { 'max-height': '75vh', 'min-height': '250px' } : {}"
         >
-            <video
-                ref="videoEl"
-                data-shaka-player
-                class="w-full"
-                :autoplay="shouldAutoPlay"
-                :loop="selectedAutoLoop"
-            ></video>
+            <video ref="videoEl" data-shaka-player class="w-full" :autoplay="shouldAutoPlay" :loop="selectedAutoLoop" />
         </div>
     </div>
 </template>

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -75,7 +75,7 @@ export default {
             .then(hotkeys => {
                 this.hotkeys = hotkeys;
                 var self = this;
-                hotkeys("f,m,j,k,l,c,space,up,down,left,right,0,1,2,3,4,5,6,7,8,9", function(e, handler) {
+                hotkeys("f,m,j,k,l,c,space,up,down,left,right,0,1,2,3,4,5,6,7,8,9", function (e, handler) {
                     const videoEl = self.$refs.videoEl;
                     switch (handler.key) {
                         case "f":
@@ -183,7 +183,7 @@ export default {
                 var tx = window.db.transaction("watch_history", "readonly");
                 var store = tx.objectStore("watch_history");
                 var request = store.get(this.video.id);
-                request.onsuccess = function(event) {
+                request.onsuccess = function (event) {
                     var video = event.target.result;
                     if (video && video.currentTime) {
                         videoEl.currentTime = video.currentTime;
@@ -467,7 +467,7 @@ export default {
             var tx = window.db.transaction("watch_history", "readwrite");
             var store = tx.objectStore("watch_history");
             var request = store.get(this.video.id);
-            request.onsuccess = function(event) {
+            request.onsuccess = function (event) {
                 var video = event.target.result;
                 if (video) {
                     video.currentTime = time;

--- a/src/components/Playlist.vue
+++ b/src/components/Playlist.vue
@@ -8,16 +8,16 @@
 
         <div class="grid grid-cols-2">
             <div>
-                <b
+                <strong
                     ><router-link class="uk-text-justify" :to="playlist.uploaderUrl || '/'">
                         <img :src="playlist.uploaderAvatar" loading="lazy" class="rounded-full" />
                         {{ playlist.uploader }}</router-link
-                    ></b
+                    ></strong
                 >
             </div>
             <div>
                 <div class="right-2vw absolute">
-                    <b>{{ playlist.videos }} {{ $t("video.videos") }}</b>
+                    <strong>{{ playlist.videos }} {{ $t("video.videos") }}</strong>
                     <br />
                     <a :href="getRssUrl"><font-awesome-icon icon="rss"></font-awesome-icon></a>
                 </div>

--- a/src/components/Playlist.vue
+++ b/src/components/Playlist.vue
@@ -6,12 +6,10 @@
 
         <div class="grid grid-cols-2">
             <div>
-                <strong>
-                    <router-link class="uk-text-justify" :to="playlist.uploaderUrl || '/'">
-                        <img :src="playlist.uploaderAvatar" loading="lazy" class="rounded-full" />
-                        <span v-text="playlist.uploader" />
-                    </router-link>
-                </strong>
+                <router-link class="uk-text-justify" :to="playlist.uploaderUrl || '/'">
+                    <img :src="playlist.uploaderAvatar" loading="lazy" class="rounded-full" />
+                    <strong v-text="playlist.uploader" />
+                </router-link>
             </div>
             <div>
                 <div class="right-2vw absolute">

--- a/src/components/Playlist.vue
+++ b/src/components/Playlist.vue
@@ -17,7 +17,9 @@
                 <div class="right-2vw absolute">
                     <strong v-text="`${playlist.videos} ${$t('video.videos')}`" />
                     <br />
-                    <a :href="getRssUrl"><font-awesome-icon icon="rss"></font-awesome-icon></a>
+                    <a :href="getRssUrl">
+                        <font-awesome-icon icon="rss" />
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/components/Playlist.vue
+++ b/src/components/Playlist.vue
@@ -2,22 +2,20 @@
     <ErrorHandler v-if="playlist && playlist.error" :message="playlist.message" :error="playlist.error" />
 
     <div v-if="playlist" v-show="!playlist.error">
-        <h1 class="text-center">
-            {{ playlist.name }}
-        </h1>
+        <h1 class="text-center" v-text="playlist.name" />
 
         <div class="grid grid-cols-2">
             <div>
-                <strong
-                    ><router-link class="uk-text-justify" :to="playlist.uploaderUrl || '/'">
+                <strong>
+                    <router-link class="uk-text-justify" :to="playlist.uploaderUrl || '/'">
                         <img :src="playlist.uploaderAvatar" loading="lazy" class="rounded-full" />
-                        {{ playlist.uploader }}</router-link
-                    ></strong
-                >
+                        <span v-text="playlist.uploader" />
+                    </router-link>
+                </strong>
             </div>
             <div>
                 <div class="right-2vw absolute">
-                    <strong>{{ playlist.videos }} {{ $t("video.videos") }}</strong>
+                    <strong v-text="`${playlist.videos} ${$t('video.videos')}`" />
                     <br />
                     <a :href="getRssUrl"><font-awesome-icon icon="rss"></font-awesome-icon></a>
                 </div>

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -1,14 +1,14 @@
 <template>
     <div class="uk-flex uk-flex-between uk-flex-middle">
         <button class="uk-button uk-button-text" @click="$router.go(-1) || $router.push('/')">
-            <font-awesome-icon icon="chevron-left" /><span class="ml-1.5">{{ $t("actions.back") }}</span>
+            <font-awesome-icon icon="chevron-left" /><span class="ml-1.5" v-text="$t('actions.back')" />
         </button>
         <span><h1 v-t="'titles.preferences'" class="font-bold text-center" /></span>
         <span />
     </div>
     <hr />
     <h2>SponsorBlock</h2>
-    <p>{{ $t("actions.uses_api_from") }}<a href="https://sponsor.ajay.app/">sponsor.ajay.app</a></p>
+    <p><span v-text="$t('actions.uses_api_from')" /><a href="https://sponsor.ajay.app/">sponsor.ajay.app</a></p>
     <label for="chkEnableSponsorblock"><strong v-t="'actions.enable_sponsorblock'" /></label>
     <br />
     <input
@@ -91,7 +91,7 @@
     <br />
     <select id="ddlDefaultQuality" v-model="defaultQuality" class="select w-auto" @change="onChange($event)">
         <option v-t="'actions.auto'" value="0" />
-        <option v-for="resolution in resolutions" :key="resolution" :value="resolution">{{ resolution }}p</option>
+        <option v-for="resolution in resolutions" :key="resolution" :value="resolution" v-text="`${resolution}p`" />
     </select>
     <br />
     <label for="txtBufferingGoal"><strong v-t="'actions.buffering_goal'" /></label>
@@ -101,7 +101,7 @@
     <label for="ddlCountrySelection"><strong v-t="'actions.country_selection'" /></label>
     <br />
     <select id="ddlCountrySelection" v-model="countrySelected" class="select w-auto" @change="onChange($event)">
-        <option v-for="country in countryMap" :key="country.code" :value="country.code">{{ country.name }}</option>
+        <option v-for="country in countryMap" :key="country.code" :value="country.code" v-text="country.name" />
     </select>
     <br />
     <label for="ddlDefaultHomepage"><strong v-t="'actions.default_homepage'" /></label>
@@ -138,7 +138,7 @@
     <label for="ddlLanguageSelection"><strong v-t="'actions.language_selection'" /></label>
     <br />
     <select id="ddlLanguageSelection" v-model="selectedLanguage" class="select w-auto" @change="onChange($event)">
-        <option v-for="language in languages" :key="language.code" :value="language.code">{{ language.name }}</option>
+        <option v-for="language in languages" :key="language.code" :value="language.code" v-text="language.name" />
     </select>
     <br />
     <label for="ddlEnabledCodecs"><strong v-t="'actions.enabled_codecs'" /></label>
@@ -160,19 +160,19 @@
     <table class="uk-table">
         <thead>
             <tr>
-                <th>{{ $t("preferences.instance_name") }}</th>
-                <th>{{ $t("preferences.instance_locations") }}</th>
-                <th>{{ $t("preferences.has_cdn") }}</th>
-                <th>{{ $t("preferences.ssl_score") }}</th>
+                <th v-text="$t('preferences.instance_name')" />
+                <th v-text="$t('preferences.instance_locations')" />
+                <th v-text="$t('preferences.has_cdn')" />
+                <th v-text="$t('preferences.ssl_score')" />
             </tr>
         </thead>
         <tbody v-for="instance in instances" :key="instance.name">
             <tr>
-                <td>{{ instance.name }}</td>
-                <td>{{ instance.locations }}</td>
-                <td>{{ instance.cdn == "Yes" ? $t("actions.yes") : $t("actions.no") }}</td>
+                <td v-text="instance.name" />
+                <td v-text="instance.locations" />
+                <td v-text="$t(`actions.${instance.cdn === 'Yes' ? 'yes' : 'no'}`)" />
                 <td>
-                    <a :href="sslScore(instance.apiurl)" target="_blank"> {{ $t("actions.view_ssl_score") }}</a>
+                    <a :href="sslScore(instance.apiurl)" target="_blank" v-text="$t('actions.view_ssl_score')" />
                 </td>
             </tr>
         </tbody>
@@ -180,14 +180,10 @@
 
     <hr />
 
-    <label for="ddlInstanceSelection"
-        ><strong>{{ $t("actions.instance_selection") }}:</strong></label
-    >
+    <label for="ddlInstanceSelection"><strong v-text="`${$t('actions.instance_selection')}:`" /></label>
     <br />
     <select id="ddlInstanceSelection" v-model="selectedInstance" class="select w-auto" @change="onChange($event)">
-        <option v-for="instance in instances" :key="instance.name" :value="instance.apiurl">
-            {{ instance.name }}
-        </option>
+        <option v-for="instance in instances" :key="instance.name" :value="instance.apiurl" v-text="instance.name" />
     </select>
 </template>
 

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -3,13 +3,13 @@
         <button class="uk-button uk-button-text" @click="$router.go(-1) || $router.push('/')">
             <font-awesome-icon icon="chevron-left" /><span class="ml-1.5">{{ $t("actions.back") }}</span>
         </button>
-        <span><h1 v-t="'titles.preferences'" class="font-bold text-center"/></span>
+        <span><h1 v-t="'titles.preferences'" class="font-bold text-center" /></span>
         <span />
     </div>
     <hr />
     <h2>SponsorBlock</h2>
     <p>{{ $t("actions.uses_api_from") }}<a href="https://sponsor.ajay.app/">sponsor.ajay.app</a></p>
-    <label for="chkEnableSponsorblock"><b v-t="'actions.enable_sponsorblock'"/></label>
+    <label for="chkEnableSponsorblock"><strong v-t="'actions.enable_sponsorblock'" /></label>
     <br />
     <input
         id="chkEnableSponsorblock"
@@ -19,23 +19,23 @@
         @change="onChange($event)"
     />
     <br />
-    <label for="chkSkipSponsors"><b v-t="'actions.skip_sponsors'"/></label>
+    <label for="chkSkipSponsors"><strong v-t="'actions.skip_sponsors'" /></label>
     <br />
     <input id="chkSkipSponsors" v-model="skipSponsor" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <br />
-    <label for="chkSkipIntro"><b v-t="'actions.skip_intro'"/></label>
+    <label for="chkSkipIntro"><strong v-t="'actions.skip_intro'" /></label>
     <br />
     <input id="chkSkipIntro" v-model="skipIntro" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <br />
-    <label for="chkSkipOutro"><b v-t="'actions.skip_outro'"/></label>
+    <label for="chkSkipOutro"><strong v-t="'actions.skip_outro'" /></label>
     <br />
     <input id="chkSkipOutro" v-model="skipOutro" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <br />
-    <label for="chkSkipPreview"><b v-t="'actions.skip_preview'"/></label>
+    <label for="chkSkipPreview"><strong v-t="'actions.skip_preview'" /></label>
     <br />
     <input id="chkSkipPreview" v-model="skipPreview" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <br />
-    <label for="chkSkipInteraction"><b v-t="'actions.skip_interaction'"/></label>
+    <label for="chkSkipInteraction"><strong v-t="'actions.skip_interaction'" /></label>
     <br />
     <input
         id="chkSkipInteraction"
@@ -45,7 +45,7 @@
         @change="onChange($event)"
     />
     <br />
-    <label for="chkSkipSelfPromo"><b v-t="'actions.skip_self_promo'"/></label>
+    <label for="chkSkipSelfPromo"><strong v-t="'actions.skip_self_promo'" /></label>
     <br />
     <input
         id="chkSkipSelfPromo"
@@ -55,7 +55,7 @@
         @change="onChange($event)"
     />
     <br />
-    <label for="chkSkipNonMusic"><b v-t="'actions.skip_non_music'"/></label>
+    <label for="chkSkipNonMusic"><strong v-t="'actions.skip_non_music'" /></label>
     <br />
     <input
         id="chkSkipNonMusic"
@@ -65,7 +65,7 @@
         @change="onChange($event)"
     />
     <br />
-    <label for="ddlTheme"><b v-t="'actions.theme'"/></label>
+    <label for="ddlTheme"><strong v-t="'actions.theme'" /></label>
     <br />
     <select id="ddlTheme" v-model="selectedTheme" class="select w-auto" @change="onChange($event)">
         <option v-t="'actions.auto'" value="auto" />
@@ -73,7 +73,7 @@
         <option v-t="'actions.light'" value="light" />
     </select>
     <br />
-    <label for="chkAutoPlayVideo"><b v-t="'actions.autoplay_video'"/></label>
+    <label for="chkAutoPlayVideo"><strong v-t="'actions.autoplay_video'" /></label>
     <br />
     <input
         id="chkAutoPlayVideo"
@@ -83,39 +83,39 @@
         @change="onChange($event)"
     />
     <br />
-    <label for="chkAudioOnly"><b v-t="'actions.audio_only'"/></label>
+    <label for="chkAudioOnly"><strong v-t="'actions.audio_only'" /></label>
     <br />
     <input id="chkAudioOnly" v-model="listen" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <br />
-    <label for="ddlDefaultQuality"><b v-t="'actions.default_quality'"/></label>
+    <label for="ddlDefaultQuality"><strong v-t="'actions.default_quality'" /></label>
     <br />
     <select id="ddlDefaultQuality" v-model="defaultQuality" class="select w-auto" @change="onChange($event)">
         <option v-t="'actions.auto'" value="0" />
         <option v-for="resolution in resolutions" :key="resolution" :value="resolution">{{ resolution }}p</option>
     </select>
     <br />
-    <label for="txtBufferingGoal"><b v-t="'actions.buffering_goal'"/></label>
+    <label for="txtBufferingGoal"><strong v-t="'actions.buffering_goal'" /></label>
     <br />
     <input id="txtBufferingGoal" v-model="bufferingGoal" class="input w-auto" type="text" @change="onChange($event)" />
     <br />
-    <label for="ddlCountrySelection"><b v-t="'actions.country_selection'"/></label>
+    <label for="ddlCountrySelection"><strong v-t="'actions.country_selection'" /></label>
     <br />
     <select id="ddlCountrySelection" v-model="countrySelected" class="select w-auto" @change="onChange($event)">
         <option v-for="country in countryMap" :key="country.code" :value="country.code">{{ country.name }}</option>
     </select>
     <br />
-    <label for="ddlDefaultHomepage"><b v-t="'actions.default_homepage'"/></label>
+    <label for="ddlDefaultHomepage"><strong v-t="'actions.default_homepage'" /></label>
     <br />
     <select id="ddlDefaultHomepage" v-model="defaultHomepage" class="select w-auto" @change="onChange($event)">
         <option v-t="'titles.trending'" value="trending" />
         <option v-t="'titles.feed'" value="feed" />
     </select>
     <br />
-    <label for="chkShowComments"><b v-t="'actions.show_comments'"/></label>
+    <label for="chkShowComments"><strong v-t="'actions.show_comments'" /></label>
     <br />
     <input id="chkShowComments" v-model="showComments" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <br />
-    <label for="chkMinimizeDescription"><b v-t="'actions.minimize_description_default'"/></label>
+    <label for="chkMinimizeDescription"><strong v-t="'actions.minimize_description_default'" /></label>
     <br />
     <input
         id="chkMinimizeDescription"
@@ -125,7 +125,7 @@
         @change="onChange($event)"
     />
     <br />
-    <label for="chkStoreWatchHistory"><b v-t="'actions.store_watch_history'"/></label>
+    <label for="chkStoreWatchHistory"><strong v-t="'actions.store_watch_history'" /></label>
     <br />
     <input
         id="chkStoreWatchHistory"
@@ -135,13 +135,13 @@
         @change="onChange($event)"
     />
     <br />
-    <label for="ddlLanguageSelection"><b v-t="'actions.language_selection'"/></label>
+    <label for="ddlLanguageSelection"><strong v-t="'actions.language_selection'" /></label>
     <br />
     <select id="ddlLanguageSelection" v-model="selectedLanguage" class="select w-auto" @change="onChange($event)">
         <option v-for="language in languages" :key="language.code" :value="language.code">{{ language.name }}</option>
     </select>
     <br />
-    <label for="ddlEnabledCodecs"><b v-t="'actions.enabled_codecs'"/></label>
+    <label for="ddlEnabledCodecs"><strong v-t="'actions.enabled_codecs'" /></label>
     <br />
     <select id="ddlEnabledCodecs" v-model="enabledCodecs" class="select w-auto" multiple @change="onChange($event)">
         <option value="av1">AV1</option>
@@ -149,11 +149,11 @@
         <option value="avc">AVC (h.264)</option>
     </select>
     <br />
-    <label for="chkDisableLBRY"><b v-t="'actions.disable_lbry'"/></label>
+    <label for="chkDisableLBRY"><strong v-t="'actions.disable_lbry'" /></label>
     <br />
     <input id="chkDisableLBRY" v-model="disableLBRY" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <br />
-    <label for="chkEnableLBRYProxy"><b v-t="'actions.enable_lbry_proxy'"/></label>
+    <label for="chkEnableLBRYProxy"><strong v-t="'actions.enable_lbry_proxy'" /></label>
     <br />
     <input id="chkEnableLBRYProxy" v-model="proxyLBRY" class="uk-checkbox" type="checkbox" @change="onChange($event)" />
     <h2 v-t="'actions.instances_list'" />
@@ -181,7 +181,7 @@
     <hr />
 
     <label for="ddlInstanceSelection"
-        ><b>{{ $t("actions.instance_selection") }}:</b></label
+        ><strong>{{ $t("actions.instance_selection") }}:</strong></label
     >
     <br />
     <select id="ddlInstanceSelection" v-model="selectedInstance" class="select w-auto" @change="onChange($event)">
@@ -293,7 +293,14 @@ export default {
             this.sponsorBlock = this.getPreferenceBoolean("sponsorblock", true);
             if (localStorage.getItem("selectedSkip") !== null) {
                 var skipList = localStorage.getItem("selectedSkip").split(",");
-                this.skipSponsor = this.skipIntro = this.skipOutro = this.skipPreview = this.skipInteraction = this.skipSelfPromo = this.skipMusicOffTopic = false;
+                this.skipSponsor =
+                    this.skipIntro =
+                    this.skipOutro =
+                    this.skipPreview =
+                    this.skipInteraction =
+                    this.skipSelfPromo =
+                    this.skipMusicOffTopic =
+                        false;
                 skipList.forEach(skip => {
                     switch (skip) {
                         case "sponsor":

--- a/src/components/RegisterPage.vue
+++ b/src/components/RegisterPage.vue
@@ -22,7 +22,7 @@
                 />
             </div>
             <div class="uk-form-row">
-                <a class="uk-width-1-1 btn w-auto" @click="register"> {{ $t("titles.register") }}</a>
+                <a class="uk-width-1-1 btn w-auto" @click="register" v-text="$t('titles.register')" />
             </div>
         </form>
     </div>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -19,12 +19,10 @@
 
     <div v-if="results && results.corrected" style="height: 7vh">
         <span v-text="$t('search.did_you_mean')" />
-        <em>
-            <router-link
-                :to="{ name: 'SearchResults', query: { search_query: results.suggestion } }"
-                v-text="results.suggestion"
-            />
-        </em>
+
+        <router-link :to="{ name: 'SearchResults', query: { search_query: results.suggestion } }">
+            <em v-text="results.suggestion" />
+        </router-link>
     </div>
 
     <div v-if="results" class="video-grid">
@@ -49,9 +47,10 @@
                 </router-link>
 
                 <a v-if="result.uploaderName" class="uk-text-muted" v-text="result.uploaderName" />
-                <strong v-if="result.videos >= 0"
-                    ><br v-if="result.uploaderName" /><span v-text="`${result.videos} ${$t('video.videos')}`"
-                /></strong>
+                <template v-if="result.videos >= 0">
+                    <br v-if="result.uploaderName" />
+                    <strong v-text="`${result.videos} ${$t('video.videos')}`" />
+                </template>
 
                 <br />
             </div>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -4,7 +4,7 @@
     </h1>
 
     <label for="ddlSearchFilters"
-        ><b>{{ $t("actions.filter") }}: </b></label
+        ><strong>{{ $t("actions.filter") }}: </strong></label
     >
     <select
         id="ddlSearchFilters"
@@ -23,11 +23,11 @@
 
     <div v-if="results && results.corrected" style="height: 7vh">
         {{ $t("search.did_you_mean") }}
-        <i>
+        <em>
             <router-link :to="{ name: 'SearchResults', query: { search_query: results.suggestion } }">
                 {{ results.suggestion }}
             </router-link>
-        </i>
+        </em>
     </div>
 
     <div v-if="results" class="video-grid">
@@ -56,8 +56,8 @@
                 </router-link>
 
                 <a v-if="result.uploaderName" class="uk-text-muted">{{ result.uploaderName }}</a>
-                <b v-if="result.videos >= 0"
-                    ><br v-if="result.uploaderName" />{{ result.videos }} {{ $t("video.videos") }}</b
+                <strong v-if="result.videos >= 0"
+                    ><br v-if="result.uploaderName" />{{ result.videos }} {{ $t("video.videos") }}</strong
                 >
 
                 <br />

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,7 +1,9 @@
 <template>
     <h1 class="text-center" v-text="$route.query.search_query" />
 
-    <label for="ddlSearchFilters"><strong v-text="`${$t('actions.filter')}:`" /></label>
+    <label for="ddlSearchFilters">
+        <strong v-text="`${$t('actions.filter')}:`" />
+    </label>
     <select
         id="ddlSearchFilters"
         v-model="selectedFilter"
@@ -34,21 +36,15 @@
                         <img style="width: 100%" :src="result.thumbnail" loading="lazy" />
                     </div>
                     <p>
-                        <span v-text="result.name" /><font-awesome-icon
-                            class="ml-1.5"
-                            v-if="result.verified"
-                            icon="check"
-                        ></font-awesome-icon>
+                        <span v-text="result.name" />
+                        <font-awesome-icon class="ml-1.5" v-if="result.verified" icon="check" />
                     </p>
                 </router-link>
                 <p v-if="result.description" v-text="result.description" />
                 <router-link v-if="result.uploaderUrl" class="uk-link-muted" :to="result.uploaderUrl">
                     <p>
-                        <span v-text="result.uploader" /><font-awesome-icon
-                            class="ml-1.5"
-                            v-if="result.uploaderVerified"
-                            icon="check"
-                        ></font-awesome-icon>
+                        <span v-text="result.uploader" />
+                        <font-awesome-icon class="ml-1.5" v-if="result.uploaderVerified" icon="check" />
                     </p>
                 </router-link>
 

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,11 +1,7 @@
 <template>
-    <h1 class="text-center">
-        {{ $route.query.search_query }}
-    </h1>
+    <h1 class="text-center" v-text="$route.query.search_query" />
 
-    <label for="ddlSearchFilters"
-        ><strong>{{ $t("actions.filter") }}: </strong></label
-    >
+    <label for="ddlSearchFilters"><strong v-text="`${$t('actions.filter')}:`" /></label>
     <select
         id="ddlSearchFilters"
         v-model="selectedFilter"
@@ -14,19 +10,18 @@
         style="height: 100%"
         @change="updateResults()"
     >
-        <option v-for="filter in availableFilters" :key="filter" :value="filter">
-            {{ filter.replace("_", " ") }}
-        </option>
+        <option v-for="filter in availableFilters" :key="filter" :value="filter" v-text="filter.replace('_', ' ')" />
     </select>
 
     <hr />
 
     <div v-if="results && results.corrected" style="height: 7vh">
-        {{ $t("search.did_you_mean") }}
+        <span v-text="$t('search.did_you_mean')" />
         <em>
-            <router-link :to="{ name: 'SearchResults', query: { search_query: results.suggestion } }">
-                {{ results.suggestion }}
-            </router-link>
+            <router-link
+                :to="{ name: 'SearchResults', query: { search_query: results.suggestion } }"
+                v-text="results.suggestion"
+            />
         </em>
     </div>
 
@@ -39,15 +34,17 @@
                         <img style="width: 100%" :src="result.thumbnail" loading="lazy" />
                     </div>
                     <p>
-                        {{ result.name
-                        }}<font-awesome-icon class="ml-1.5" v-if="result.verified" icon="check"></font-awesome-icon>
+                        <span v-text="result.name" /><font-awesome-icon
+                            class="ml-1.5"
+                            v-if="result.verified"
+                            icon="check"
+                        ></font-awesome-icon>
                     </p>
                 </router-link>
-                <p v-if="result.description">{{ result.description }}</p>
+                <p v-if="result.description" v-text="result.description" />
                 <router-link v-if="result.uploaderUrl" class="uk-link-muted" :to="result.uploaderUrl">
                     <p>
-                        {{ result.uploader
-                        }}<font-awesome-icon
+                        <span v-text="result.uploader" /><font-awesome-icon
                             class="ml-1.5"
                             v-if="result.uploaderVerified"
                             icon="check"
@@ -55,10 +52,10 @@
                     </p>
                 </router-link>
 
-                <a v-if="result.uploaderName" class="uk-text-muted">{{ result.uploaderName }}</a>
+                <a v-if="result.uploaderName" class="uk-text-muted" v-text="result.uploaderName" />
                 <strong v-if="result.videos >= 0"
-                    ><br v-if="result.uploaderName" />{{ result.videos }} {{ $t("video.videos") }}</strong
-                >
+                    ><br v-if="result.uploaderName" /><span v-text="`${result.videos} ${$t('video.videos')}`"
+                /></strong>
 
                 <br />
             </div>

--- a/src/components/SearchSuggestions.vue
+++ b/src/components/SearchSuggestions.vue
@@ -8,9 +8,8 @@
                 :class="{ 'suggestion-selected': selected === i }"
                 @mouseover="onMouseOver(i)"
                 @mousedown.stop="onClick(i)"
-            >
-                {{ suggestion }}
-            </li>
+                v-text="suggestion"
+            />
         </ul>
     </div>
 </template>

--- a/src/components/Sorting.vue
+++ b/src/components/Sorting.vue
@@ -1,0 +1,44 @@
+<template>
+    <label for="ddlSortBy" v-text="$t('actions.sort_by')" />
+    <select id="ddlSortBy" v-model="selectedSort" class="select w-auto">
+        <option v-for="(value, key) in options" v-t="`actions.${key}`" :key="key" :value="value" />
+    </select>
+</template>
+
+<script setup>
+import { defineEmits, defineProps, ref, watch } from "vue";
+
+const options = {
+    most_recent: "descending",
+    least_recent: "ascending",
+    channel_name_asc: "channel_ascending",
+    channel_name_desc: "channel_descending",
+};
+
+const selectedSort = ref("descending");
+
+const props = defineProps({
+    byKey: String,
+});
+
+const emit = defineEmits(["apply"]);
+
+watch(selectedSort, value => {
+    switch (value) {
+        case "ascending":
+            emit("apply", (a, b) => a[props.byKey] - b[props.byKey]);
+            break;
+        case "descending":
+            emit("apply", (a, b) => b[props.byKey] - a[props.byKey]);
+            break;
+        case "channel_ascending":
+            emit("apply", (a, b) => a.uploaderName.localeCompare(b.uploaderName));
+            break;
+        case "channel_descending":
+            emit("apply", (a, b) => b.uploaderName.localeCompare(a.uploaderName));
+            break;
+        default:
+            console.error("Unexpected sort value");
+    }
+});
+</script>

--- a/src/components/SubscriptionsPage.vue
+++ b/src/components/SubscriptionsPage.vue
@@ -1,16 +1,12 @@
 <template>
-    <h1 class="font-bold text-center">{{ $t("titles.subscriptions") }}</h1>
+    <h1 class="font-bold text-center" v-text="$t('titles.subscriptions')" />
 
     <div v-if="authenticated">
         <button class="btn mr-0.5">
-            <router-link to="/import">
-                {{ $t("actions.import_from_json") }}
-            </router-link>
+            <router-link to="/import" v-text="$t('actions.import_from_json')" />
         </button>
 
-        <button class="btn" @click="exportHandler">
-            {{ $t("actions.export_to_json") }}
-        </button>
+        <button class="btn" @click="exportHandler" v-text="$t('actions.export_to_json')" />
     </div>
     <hr />
 
@@ -20,11 +16,13 @@
                 <div class="w-full grid grid-cols-3">
                     <router-link :to="subscription.url" class="col-start-2 block flex text-center font-bold text-4xl">
                         <img :src="subscription.avatar" class="rounded-full" width="48" height="48" />
-                        <span>{{ subscription.name }}</span>
+                        <span v-text="subscription.name" />>
                     </router-link>
-                    <button class="btn !w-min" @click="handleButton(subscription)">
-                        {{ subscription.subscribed ? $t("actions.unsubscribe") : $t("actions.subscribe") }}
-                    </button>
+                    <button
+                        class="btn !w-min"
+                        @click="handleButton(subscription)"
+                        v-text="$t(`actions.${subscription.subscribed ? 'unsubscribe' : 'subscribe'}`)"
+                    />
                 </div>
             </div>
         </div>

--- a/src/components/SubscriptionsPage.vue
+++ b/src/components/SubscriptionsPage.vue
@@ -16,7 +16,7 @@
                 <div class="w-full grid grid-cols-3">
                     <router-link :to="subscription.url" class="col-start-2 block flex text-center font-bold text-4xl">
                         <img :src="subscription.avatar" class="rounded-full" width="48" height="48" />
-                        <span v-text="subscription.name" />>
+                        <span v-text="subscription.name" />
                     </router-link>
                     <button
                         class="btn !w-min"

--- a/src/components/TrendingPage.vue
+++ b/src/components/TrendingPage.vue
@@ -1,5 +1,5 @@
 <template>
-    <h1 v-t="'titles.trending'" class="font-bold text-center" />
+    <h1 v-t="$t('titles.trending')" class="font-bold text-center" />
 
     <hr />
 

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -3,12 +3,18 @@
         <router-link :to="video.url">
             <img :height="height" :width="width" class="w-full" :src="video.thumbnail" alt="" loading="lazy" />
             <div class="relative text-sm">
-                <span v-if="video.duration" class="thumbnail-overlay bottom-5px right-5px" style="padding: 0 5px">{{
-                    timeFormat(video.duration)
-                }}</span>
-                <span v-if="video.watched" class="thumbnail-overlay bottom-5px left-5px" style="padding: 0 5px">{{
-                    $t("video.watched")
-                }}</span>
+                <span
+                    v-if="video.duration"
+                    class="thumbnail-overlay bottom-5px right-5px"
+                    style="padding: 0 5px"
+                    v-text="timeFormat(video.duration)"
+                />
+                <span
+                    v-if="video.watched"
+                    class="thumbnail-overlay bottom-5px left-5px"
+                    style="padding: 0 5px"
+                    v-text="$t('video.watched')"
+                />
             </div>
 
             <div>
@@ -16,9 +22,8 @@
                     style="display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical"
                     class="my-2 overflow-hidden flex link"
                     :title="video.title"
-                >
-                    {{ video.title }}
-                </p>
+                    v-text="video.title"
+                />
             </div>
         </router-link>
 
@@ -52,21 +57,17 @@
                     :to="video.uploaderUrl"
                     :title="video.uploaderName"
                 >
-                    {{ video.uploaderName
-                    }}<font-awesome-icon class="ml-1.5" v-if="video.uploaderVerified" icon="check"></font-awesome-icon>
+                    <span v-text="video.uploaderName" />
+                    <font-awesome-icon class="ml-1.5" v-if="video.uploaderVerified" icon="check"></font-awesome-icon>
                 </router-link>
 
                 <strong v-if="video.views >= 0 || video.uploadedDate" class="uk-text-small">
                     <span v-if="video.views >= 0">
                         <font-awesome-icon icon="eye"></font-awesome-icon>
-                        {{ numberFormat(video.views) }} •
+                        <span v-text="`${numberFormat(video.views)} •`" />
                     </span>
-                    <span v-if="video.uploadedDate">
-                        {{ video.uploadedDate }}
-                    </span>
-                    <span v-if="video.uploaded">
-                        {{ timeAgo(video.uploaded) }}
-                    </span>
+                    <span v-if="video.uploadedDate" v-text="video.uploadedDate" />
+                    <span v-if="video.uploaded" v-text="timeAgo(video.uploaded)" />
                 </strong>
             </div>
         </div>

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -56,7 +56,7 @@
                     }}<font-awesome-icon class="ml-1.5" v-if="video.uploaderVerified" icon="check"></font-awesome-icon>
                 </router-link>
 
-                <b v-if="video.views >= 0 || video.uploadedDate" class="uk-text-small">
+                <strong v-if="video.views >= 0 || video.uploadedDate" class="uk-text-small">
                     <span v-if="video.views >= 0">
                         <font-awesome-icon icon="eye"></font-awesome-icon>
                         {{ numberFormat(video.views) }} •
@@ -67,7 +67,7 @@
                     <span v-if="video.uploaded">
                         {{ timeAgo(video.uploaded) }}
                     </span>
-                </b>
+                </strong>
             </div>
         </div>
     </div>

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -33,7 +33,7 @@
                 :aria-label="'Listen to ' + video.title"
                 :title="'Listen to ' + video.title"
             >
-                <font-awesome-icon icon="headphones"></font-awesome-icon>
+                <font-awesome-icon icon="headphones" />
             </router-link>
         </div>
 
@@ -58,12 +58,12 @@
                     :title="video.uploaderName"
                 >
                     <span v-text="video.uploaderName" />
-                    <font-awesome-icon class="ml-1.5" v-if="video.uploaderVerified" icon="check"></font-awesome-icon>
+                    <font-awesome-icon class="ml-1.5" v-if="video.uploaderVerified" icon="check" />
                 </router-link>
 
                 <strong v-if="video.views >= 0 || video.uploadedDate" class="uk-text-small">
                     <span v-if="video.views >= 0">
-                        <font-awesome-icon icon="eye"></font-awesome-icon>
+                        <font-awesome-icon icon="eye" />
                         <span v-text="`${numberFormat(video.views)} •`" />
                     </span>
                     <span v-if="video.uploadedDate" v-text="video.uploadedDate" />

--- a/src/components/VideoRedirect.vue
+++ b/src/components/VideoRedirect.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>{{ $t("actions.loading") }}</div>
+    <div v-text="$t('actions.loading')" />
 </template>
 
 <script>

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -21,23 +21,21 @@
                 :selected-auto-play="selectedAutoPlay"
                 :selected-auto-loop="selectedAutoLoop"
             />
-            <div class="font-bold mt-2 text-2xl break-words">
-                {{ video.title }}
-            </div>
+            <div class="font-bold mt-2 text-2xl break-words" v-text="video.title" />
 
             <div class="flex mb-1.5">
-                <span>{{ addCommas(video.views) }} views</span>
-                <span class="ml-2">{{ uploadDate }}</span>
+                <span v-text="`${addCommas(video.views)} views`" />
+                <span class="ml-2" v-text="uploadDate" />
 
                 <div class="flex items-center relative ml-auto children:ml-2">
                     <template v-if="video.likes >= 0">
                         <div>
                             <font-awesome-icon icon="thumbs-up"></font-awesome-icon>
-                            <strong class="ml-2">{{ addCommas(video.likes) }}</strong>
+                            <strong class="ml-2" v-text="addCommas(video.likes)" />
                         </div>
                         <div>
                             <font-awesome-icon icon="thumbs-down"></font-awesome-icon>
-                            <strong class="ml-2">{{ video.dislikes >= 0 ? addCommas(video.dislikes) : "?" }}</strong>
+                            <strong class="ml-2" v-text="video.dislikes >= 0 ? addCommas(video.dislikes) : '?'" />
                         </div>
                     </template>
                     <template v-if="video.likes < 0">
@@ -45,12 +43,12 @@
                             <strong v-t="'video.ratings_disabled'" />
                         </div>
                     </template>
-                    <a :href="'https://youtu.be/' + getVideoId()" class="btn">
-                        <strong>{{ $t("player.watch_on") }}</strong>
+                    <a :href="`https://youtu.be/${getVideoId()}`" class="btn">
+                        <strong v-text="$t('player.watch_on')" />
                         <font-awesome-icon class="ml-1.5" :icon="['fab', 'youtube']"></font-awesome-icon>
                     </a>
                     <a v-if="video.lbryId" :href="'https://odysee.com/' + video.lbryId" class="btn">
-                        <strong>{{ $t("player.watch_on") }} LBRY</strong>
+                        <strong v-text="`${$t('player.watch_on')} LBRY`" />
                     </a>
                     <router-link
                         :to="toggleListenUrl"
@@ -66,37 +64,42 @@
             <div class="flex">
                 <div class="flex items-center">
                     <img :src="video.uploaderAvatar" alt="" loading="lazy" class="rounded-full" />
-                    <router-link v-if="video.uploaderUrl" class="link ml-1.5" :to="video.uploaderUrl">
-                        {{ video.uploader }} </router-link
-                    ><font-awesome-icon class="ml-1" v-if="video.uploaderVerified" icon="check"></font-awesome-icon>
+                    <router-link
+                        v-if="video.uploaderUrl"
+                        class="link ml-1.5"
+                        :to="video.uploaderUrl"
+                        v-text="video.uploader"
+                    /><font-awesome-icon class="ml-1" v-if="video.uploaderVerified" icon="check"></font-awesome-icon>
                 </div>
-                <button v-if="authenticated" class="btn relative ml-auto" @click="subscribeHandler">
-                    {{ subscribed ? $t("actions.unsubscribe") : $t("actions.subscribe") }}
-                </button>
+                <button
+                    v-if="authenticated"
+                    class="btn relative ml-auto"
+                    @click="subscribeHandler"
+                    v-text="$t(`actions.${subscribed ? 'unsubscribe' : 'subscribe'}`)"
+                />
             </div>
 
             <hr />
 
-            <button class="btn mb-2" @click="showDesc = !showDesc">
-                {{ showDesc ? $t("actions.minimize_description") : $t("actions.show_description") }}
-            </button>
+            <button
+                class="btn mb-2"
+                @click="showDesc = !showDesc"
+                v-text="$t(`actions.${showDesc ? 'minimize_description' : 'show_description'}`)"
+            />
             <!-- eslint-disable-next-line vue/no-v-html -->
             <p v-show="showDesc" class="break-words" v-html="purifyHTML(video.description)"></p>
-            <div v-if="showDesc && sponsors && sponsors.segments">
-                {{ $t("video.sponsor_segments") }}: {{ sponsors.segments.length }}
-            </div>
+            <div
+                v-if="showDesc && sponsors && sponsors.segments"
+                v-text="`${$t('video.sponsor_segments')}: ${sponsors.segments.length}`"
+            />
         </div>
 
         <hr />
 
-        <label for="chkAutoLoop"
-            ><strong>{{ $t("actions.loop_this_video") }}:</strong></label
-        >
+        <label for="chkAutoLoop"><strong v-text="`${$t('actions.loop_this_video')}:`" /></label>
         <input id="chkAutoLoop" v-model="selectedAutoLoop" class="ml-1.5" type="checkbox" @change="onChange($event)" />
         <br />
-        <label for="chkAutoPlay"
-            ><strong>{{ $t("actions.auto_play_next_video") }}:</strong></label
-        >
+        <label for="chkAutoPlay"><strong v-text="`${$t('actions.auto_play_next_video')}:`" /></label>
         <input id="chkAutoPlay" v-model="selectedAutoPlay" class="ml-1.5" type="checkbox" @change="onChange($event)" />
 
         <hr />
@@ -113,9 +116,11 @@
             </div>
 
             <div v-if="video" class="order-first sm:order-last">
-                <a class="btn mb-2 sm:hidden" @click="showRecs = !showRecs">
-                    {{ showRecs ? $t("actions.minimize_recommendations") : $t("actions.show_recommendations") }}
-                </a>
+                <a
+                    class="btn mb-2 sm:hidden"
+                    @click="showRecs = !showRecs"
+                    v-text="$t(`actions.${showRecs ? 'minimize_recommendations' : 'show_recommendations'}`)"
+                />
                 <VideoItem
                     v-for="related in video.relatedStreams"
                     class="w-auto"

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -30,11 +30,11 @@
                 <div class="flex items-center relative ml-auto children:ml-2">
                     <template v-if="video.likes >= 0">
                         <div>
-                            <font-awesome-icon icon="thumbs-up"></font-awesome-icon>
+                            <font-awesome-icon icon="thumbs-up" />
                             <strong class="ml-2" v-text="addCommas(video.likes)" />
                         </div>
                         <div>
-                            <font-awesome-icon icon="thumbs-down"></font-awesome-icon>
+                            <font-awesome-icon icon="thumbs-down" />
                             <strong class="ml-2" v-text="video.dislikes >= 0 ? addCommas(video.dislikes) : '?'" />
                         </div>
                     </template>
@@ -45,7 +45,7 @@
                     </template>
                     <a :href="`https://youtu.be/${getVideoId()}`" class="btn">
                         <strong v-text="$t('player.watch_on')" />
-                        <font-awesome-icon class="ml-1.5" :icon="['fab', 'youtube']"></font-awesome-icon>
+                        <font-awesome-icon class="ml-1.5" :icon="['fab', 'youtube']" />
                     </a>
                     <a v-if="video.lbryId" :href="'https://odysee.com/' + video.lbryId" class="btn">
                         <strong v-text="`${$t('player.watch_on')} LBRY`" />
@@ -56,7 +56,7 @@
                         :title="(isListening ? 'Watch ' : 'Listen to ') + video.title"
                         class="btn"
                     >
-                        <font-awesome-icon :icon="isListening ? 'tv' : 'headphones'"></font-awesome-icon>
+                        <font-awesome-icon :icon="isListening ? 'tv' : 'headphones'" />
                     </router-link>
                 </div>
             </div>
@@ -69,7 +69,8 @@
                         class="link ml-1.5"
                         :to="video.uploaderUrl"
                         v-text="video.uploader"
-                    /><font-awesome-icon class="ml-1" v-if="video.uploaderVerified" icon="check"></font-awesome-icon>
+                    />
+                    <font-awesome-icon class="ml-1" v-if="video.uploaderVerified" icon="check" />
                 </div>
                 <button
                     v-if="authenticated"
@@ -87,7 +88,7 @@
                 v-text="$t(`actions.${showDesc ? 'minimize_description' : 'show_description'}`)"
             />
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <p v-show="showDesc" class="break-words" v-html="purifyHTML(video.description)"></p>
+            <p v-show="showDesc" class="break-words" v-html="purifyHTML(video.description)" />
             <div
                 v-if="showDesc && sponsors && sponsors.segments"
                 v-text="`${$t('video.sponsor_segments')}: ${sponsors.segments.length}`"

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -199,7 +199,7 @@ export default {
                     var tx = window.db.transaction("watch_history", "readwrite");
                     var store = tx.objectStore("watch_history");
                     var request = store.get(videoId);
-                    request.onsuccess = function(event) {
+                    request.onsuccess = function (event) {
                         var video = event.target.result;
                         if (video) {
                             video.watchedAt = Date.now();

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -33,24 +33,24 @@
                     <template v-if="video.likes >= 0">
                         <div>
                             <font-awesome-icon icon="thumbs-up"></font-awesome-icon>
-                            <b class="ml-2">{{ addCommas(video.likes) }}</b>
+                            <strong class="ml-2">{{ addCommas(video.likes) }}</strong>
                         </div>
                         <div>
                             <font-awesome-icon icon="thumbs-down"></font-awesome-icon>
-                            <b class="ml-2">{{ video.dislikes >= 0 ? addCommas(video.dislikes) : "?" }}</b>
+                            <strong class="ml-2">{{ video.dislikes >= 0 ? addCommas(video.dislikes) : "?" }}</strong>
                         </div>
                     </template>
                     <template v-if="video.likes < 0">
                         <div>
-                            <b v-t="'video.ratings_disabled'" />
+                            <strong v-t="'video.ratings_disabled'" />
                         </div>
                     </template>
                     <a :href="'https://youtu.be/' + getVideoId()" class="btn">
-                        <b>{{ $t("player.watch_on") }}</b>
+                        <strong>{{ $t("player.watch_on") }}</strong>
                         <font-awesome-icon class="ml-1.5" :icon="['fab', 'youtube']"></font-awesome-icon>
                     </a>
                     <a v-if="video.lbryId" :href="'https://odysee.com/' + video.lbryId" class="btn">
-                        <b>{{ $t("player.watch_on") }} LBRY</b>
+                        <strong>{{ $t("player.watch_on") }} LBRY</strong>
                     </a>
                     <router-link
                         :to="toggleListenUrl"
@@ -90,12 +90,12 @@
         <hr />
 
         <label for="chkAutoLoop"
-            ><b>{{ $t("actions.loop_this_video") }}:</b></label
+            ><strong>{{ $t("actions.loop_this_video") }}:</strong></label
         >
         <input id="chkAutoLoop" v-model="selectedAutoLoop" class="ml-1.5" type="checkbox" @change="onChange($event)" />
         <br />
         <label for="chkAutoPlay"
-            ><b>{{ $t("actions.auto_play_next_video") }}:</b></label
+            ><strong>{{ $t("actions.auto_play_next_video") }}:</strong></label
         >
         <input id="chkAutoPlay" v-model="selectedAutoPlay" class="ml-1.5" type="checkbox" @change="onChange($event)" />
 

--- a/src/main.js
+++ b/src/main.js
@@ -57,8 +57,8 @@ import("./registerServiceWorker");
 
 const mixin = {
     methods: {
-        timeFormat: function(duration) {
-            var pad = function(num, size) {
+        timeFormat: function (duration) {
+            var pad = function (num, size) {
                 return ("000" + num).slice(size * -1);
             };
 
@@ -95,7 +95,7 @@ const mixin = {
             num = parseInt(num);
             return num.toLocaleString("en-US");
         },
-        fetchJson: function(url, params, options) {
+        fetchJson: function (url, params, options) {
             if (params) {
                 url = new URL(url);
                 for (var param in params) url.searchParams.set(param, params[param]);
@@ -152,7 +152,7 @@ const mixin = {
             return this.getPreferenceString("authToken" + this.hashCode(this.apiUrl()));
         },
         hashCode(s) {
-            return s.split("").reduce(function(a, b) {
+            return s.split("").reduce(function (a, b) {
                 a = (a << 5) - a + b.charCodeAt(0);
                 return a & a;
             }, 0);
@@ -173,7 +173,7 @@ const mixin = {
                 var store = tx.objectStore("watch_history");
                 videos.map(async video => {
                     var request = store.get(video.url.substr(-11));
-                    request.onsuccess = function(event) {
+                    request.onsuccess = function (event) {
                         if (event.target.result) {
                             video.watched = true;
                         }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -70,7 +70,7 @@ const routes = [
 const router = createRouter({
     history: createWebHistory(),
     routes,
-    scrollBehavior: function(_to, _from, savedPosition) {
+    scrollBehavior: function (_to, _from, savedPosition) {
         return savedPosition ? savedPosition : window.scrollTo(0, 0);
     },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import WindiCSS from "vite-plugin-windicss";
 import vueI18n from "@intlify/vite-plugin-vue-i18n";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "path";
+import eslintPlugin from "vite-plugin-eslint";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -41,6 +42,7 @@ export default defineConfig({
                 ],
             },
         }),
+        eslintPlugin(),
     ],
     resolve: {
         alias: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,6 +1909,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
@@ -1951,7 +1956,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@^7.32.0:
+eslint@^7.26.0, eslint@^7.32.0:
   version "7.32.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
   integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
@@ -2942,7 +2947,7 @@ rollup-plugin-terser@^7.0.0:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.43.1, rollup@^2.59.0, rollup@^2.60.2:
+rollup@^2.43.1, rollup@^2.47.0, rollup@^2.59.0, rollup@^2.60.2:
   version "2.62.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.62.0.tgz#9e640b419fc5b9e0241844f6d55258bd79986ecc"
   integrity sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==
@@ -3316,6 +3321,15 @@ v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
+vite-plugin-eslint@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-eslint/-/vite-plugin-eslint-1.3.0.tgz#cbc3f1542ca5e90d592ccfb6b4957e9b63f99a0e"
+  integrity sha512-ng6liBWegj6bovfJVGsXXL2XeQR3xnqe4UsnwTE8rbsYTnAaiLfaZK3rruGAyiwCBPbBc2IEED6T7sus5NJfEw==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.0"
+    eslint "^7.26.0"
+    rollup "^2.47.0"
 
 vite-plugin-pwa@^0.11.12:
   version "0.11.12"


### PR DESCRIPTION
This is a minor refactor done in order to ease the transition to windicss. I wish to rewrite the whole project with typescript, fully transition to the composition api using script setup and convert mixins to composable functions.

I'd also like to move from webpack to [vite](https://vitejs.dev/guide/why.html#slow-server-start), as this is where all the nice things are at this moment (like pretty much instant dev server start, and plenty of plugins), as well as to move from yarn (slower, FB owned) to [pnpm](https://pnpm.io/).

I wanted to limit changes to mostly HTML, but there are many places where logic itself could be improved by using optional chaining, nullish coalescing operator, or simply using await keyword instead of assigning values inside `then` callback.

If you are okay with my contribution, let me know in the comment.