### PR TITLE
audio only seek in listen mode

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -33,6 +33,10 @@ export default {
         selectedAutoPlay: Boolean,
         selectedAutoLoop: Boolean,
         isEmbed: Boolean,
+        onlyAudio: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
@@ -442,7 +446,7 @@ export default {
 
             this.$player = player;
 
-            const disableVideo = this.getPreferenceBoolean("listen", false) && !this.video.livestream;
+            const disableVideo = this.getPreferenceBoolean("listen", this.onlyAudio) && !this.video.livestream;
 
             this.$player.configure({
                 preferredVideoCodecs: this.preferredVideoCodecs,

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -20,6 +20,7 @@
                 :sponsors="sponsors"
                 :selected-auto-play="selectedAutoPlay"
                 :selected-auto-loop="selectedAutoLoop"
+                :only-audio="isListening"
             />
             <div class="font-bold mt-2 text-2xl break-words" v-text="video.title" />
 


### PR DESCRIPTION
This patch fixes the following problem: when a user selects audio only option below the
video title, On clicking the video chapters, The video plays instead of audio.