### PR TITLE
Make URLs in video description links

### DIFF
--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -89,7 +89,7 @@
                 v-t="`actions.${showDesc ? 'minimize_description' : 'show_description'}`"
             />
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <p v-show="showDesc" class="break-words" v-html="urlify(purifyHTML(video.description))" />
+            <div v-show="showDesc" class="break-words" v-html="urlify(purifyHTML(video.description))" />
             <Chapters v-if="video?.chapters?.length > 0" :chapters="video.chapters" @seek="navigate" />
             <div
                 v-if="showDesc && sponsors && sponsors.segments"

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -89,7 +89,7 @@
                 v-t="`actions.${showDesc ? 'minimize_description' : 'show_description'}`"
             />
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <div v-show="showDesc" class="break-words" v-html="urlify(purifyHTML(video.description))" />
+            <div v-show="showDesc" class="break-words" v-html="purifyHTML(video.description)" />
             <Chapters v-if="video?.chapters?.length > 0" :chapters="video.chapters" @seek="navigate" />
             <div
                 v-if="showDesc && sponsors && sponsors.segments"
@@ -281,7 +281,11 @@ export default {
                         this.channelId = this.video.uploaderUrl.split("/")[2];
                         if (!this.isEmbed) this.fetchSubscribedStatus();
 
-                        this.video.description = this.video.description
+                        const parser = new DOMParser();
+                        const xmlDoc = parser.parseFromString(this.video.description, "text/html");
+                        xmlDoc.querySelectorAll("a").forEach(elem => (elem.outerHTML = elem.getAttribute("href")));
+                        xmlDoc.querySelectorAll("br").forEach(elem => (elem.outerHTML = "\n"));
+                        this.video.description = this.urlify(xmlDoc.querySelector("body").innerHTML)
                             .replaceAll(/(?:http(?:s)?:\/\/)?(?:www\.)?youtube\.com(\/[/a-zA-Z0-9?=&]*)/gm, "$1")
                             .replaceAll(
                                 /(?:http(?:s)?:\/\/)?(?:www\.)?youtu\.be\/(?:watch\?v=)?([/a-zA-Z0-9?=&]*)/gm,

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -89,7 +89,7 @@
                 v-t="`actions.${showDesc ? 'minimize_description' : 'show_description'}`"
             />
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <p v-show="showDesc" class="break-words" v-html="purifyHTML(video.description)" />
+            <p v-show="showDesc" class="break-words" v-html="urlify(purifyHTML(video.description))" />
             <Chapters v-if="video?.chapters?.length > 0" :chapters="video.chapters" @seek="navigate" />
             <div
                 v-if="showDesc && sponsors && sponsors.segments"


### PR DESCRIPTION
Currently, if a video has links in it's description you are unable to click and follow the link.

For example:
[Piped](https://piped.kavin.rocks/watch?v=Qt_-nVOGjKo)
[Invidious](https://inv.riverside.rocks/watch?v=Qt_-nVOGjKo)
[YouTube](https://www.youtube.com/watch?v=Qt_-nVOGjKo)

To do this I just parse the video's description through a `urlify` function I found laying around. Thinking about this now; is it possible to run this parsing when this `video` object (? I couldn't find where it actually came from, still new to Vue) is created?

This might eventually want to be expanded to hashtags as well.

This is my first time messing about with Vue/contributing to this project, so sorry if I've done something wrong/against common conventions.