### PR TITLE
Restrict the home link to only logo width

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,6 +1,6 @@
 <template>
     <nav class="flex flex-wrap items-center justify-center px-2 sm:px-4 py-2.5 w-full relative">
-        <div class="flex-1">
+        <div class="flex-1 flex justify-start">
             <router-link class="flex font-bold text-3xl items-center font-sans font-bold" to="/"
                 ><img
                     alt="logo"


### PR DESCRIPTION
Currently, the home link at the top covers the whole space to the left of search bar. This restricts it to just the logo.

Fixes #746