### PR TITLE
Move all controls in overflow menu to main panel

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -416,18 +416,30 @@ export default {
                     }
                 };
 
-                shaka.ui.OverflowMenu.registerElement("open_new_tab", new OpenButton.Factory());
+                shaka.ui.Controls.registerElement("open_new_tab", new OpenButton.Factory());
 
                 this.$ui = new shaka.ui.Overlay(localPlayer, this.$refs.container, videoEl);
 
-                const overflowMenuButtons = ["quality", "captions", "picture_in_picture", "playback_rate", "airplay"];
+                const controlPanelElements = [
+                    "play_pause",
+                    "time_and_duration",
+                    "spacer",
+                    "mute",
+                    "volume",
+                    "captions",
+                    "quality",
+                    "playback_rate",
+                    "picture_in_picture",
+                    "airplay",
+                    "fullscreen",
+                ];
 
                 if (this.isEmbed) {
-                    overflowMenuButtons.push("open_new_tab");
+                    controlPanelElements.push("open_new_tab");
                 }
 
                 const config = {
-                    overflowMenuButtons: overflowMenuButtons,
+                    controlPanelElements: controlPanelElements,
                     seekBarColors: {
                         base: "rgba(255, 255, 255, 0.3)",
                         buffered: "rgba(255, 255, 255, 0.54)",

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -447,6 +447,12 @@ export default {
                     },
                 };
 
+                if (this.$ui.isMobile()) {
+                    config.controlPanelElements = config.controlPanelElements.filter(
+                        prop => prop != "play_pause" && prop != "volume",
+                    );
+                }
+
                 this.$ui.configure(config);
             }
 

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -445,12 +445,14 @@ export default {
                         buffered: "rgba(255, 255, 255, 0.54)",
                         played: "rgb(255, 0, 0)",
                     },
+                    enableTooltips: true,
                 };
 
                 if (this.$ui.isMobile()) {
                     config.controlPanelElements = config.controlPanelElements.filter(
                         prop => prop != "play_pause" && prop != "volume",
                     );
+                    config.enableTooltips = false;
                 }
 
                 this.$ui.configure(config);


### PR DESCRIPTION
These changes might be subjective but now it takes one less step to change controls. Enabled tooltips so current applied values can be seen with hover, except for mobile because tooltips are hard to trigger on mobile and might actually be annoying.

Screenshots:

![Screenshot from 2022-03-14 21-26-35](https://user-images.githubusercontent.com/58942389/158217162-cb4c3d22-7c4d-4cc2-9753-334adbdd41d6.png)

![Screenshot from 2022-03-14 21-18-25](https://user-images.githubusercontent.com/58942389/158217229-dbd0d867-13bf-4c52-80c5-ba2e859fea01.png)

