### PR TITLE
fix the broken channel image height

### DIFF
--- a/src/components/SubscriptionsPage.vue
+++ b/src/components/SubscriptionsPage.vue
@@ -15,7 +15,7 @@
             <div class="flex justify-center place-items-center">
                 <div class="w-full grid grid-cols-3">
                     <router-link :to="subscription.url" class="col-start-2 block flex text-center font-bold text-4xl">
-                        <img :src="subscription.avatar" class="rounded-full" width="48" height="48" />
+                        <img :src="subscription.avatar" class="rounded-full channel" width="48" height="48" />
                         <span v-text="subscription.name" />
                     </router-link>
                     <button
@@ -95,3 +95,8 @@ export default {
     },
 };
 </script>
+<style>
+img.rounded-full.channel {
+    height: fit-content;
+}
+</style>


### PR DESCRIPTION
super simple fix, the image height is initially set to `auto` but that causes this issue when viewing subscription at the wrong aspect ratio:
![image](https://user-images.githubusercontent.com/60309933/158729836-445ad968-ea95-42b9-817f-e1e1055fca85.png)
This fix simply changes the image height adjust for channels to `fit-content`, which fixes the icons to look more like this:
![image](https://user-images.githubusercontent.com/60309933/158729939-61f3a0c3-1810-43c2-bea6-a585de56bfdf.png)
:bread: Much love :smiling_face_with_three_hearts: 