### PR TITLE
show message if comments are disabled in a video

### DIFF
--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -121,7 +121,13 @@
         <hr />
 
         <div class="grid xl:grid-cols-5 sm:grid-cols-4 grid-cols-1">
-            <div v-if="comments" ref="comments" class="xl:col-span-4 sm:col-span-3">
+            <div v-if="!comments" class="xl:col-span-4 sm:col-span-3">
+                <p class="text-center mt-8">Comments are loading...</p>
+            </div>
+            <div v-else-if="comments.disabled" class="xl:col-span-4 sm:col-span-3">
+                <p class="text-center mt-8">Comments are turned off.</p>
+            </div>
+            <div v-else ref="comments" class="xl:col-span-4 sm:col-span-3">
                 <CommentItem
                     v-for="comment in comments.comments"
                     :key="comment.commentId"


### PR DESCRIPTION
i think it would be nice to show something if comments are disabled in a particular video for QOL, i also added an indicator if comments are still loading.

**Preview**
![if-comments-disabled](https://user-images.githubusercontent.com/62589492/168589497-9976a189-337b-45d4-8602-ea4831a472c4.gif)

