### PR TITLE
Use a relative url with router-link (fixes: #1194)

### DIFF
--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -251,7 +251,7 @@ export default {
         toggleListenUrl(_this) {
             const url = new URL(window.location.href);
             url.searchParams.set("listen", _this.isListening ? "0" : "1");
-            return url.href;
+            return url.pathname + url.search;
         },
         isEmbed(_this) {
             return String(_this.$route.path).indexOf("/embed/") == 0;


### PR DESCRIPTION
Good evening,

First of all, thanks for your work on this amazing project!

I recently stumbled across a bug while using the "listen" feature on a video (#1194). After a few researches, it seems that the `toggleListenUrl` function return an absolute url path to the `<router-link>` component, which can only accept relative paths (vuejs/vue-router#1131).

So I fixed it by making it return `url.pathname + url.search` instead, which is the concatenation of the relative path and the URL query parameters.

As this is my first pull request ever, feel free to correct me if I have done anything wrong. :wink:

Regards,

Ikkibird