### PR TITLE
Replaces Privacy Redirect with Libredirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The documentation can be found at https://piped-docs.kavin.rocks (accessible via
 
 ## Extensions
 
-To redirect all YouTube links to Piped, you are highly recommended to use either [Piped-Redirects](https://github.com/TeamPiped/Piped-Redirects) or [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect#get).
+To redirect all YouTube links to Piped, you are highly recommended to use either [Piped-Redirects](https://github.com/TeamPiped/Piped-Redirects) or [Libredirect](https://github.com/libredirect/libredirect#readme).
 
 ## Contributing
 


### PR DESCRIPTION
Privacy Redirect hasn't been actively updated in almost a year now (25 Jul, 2021) so I think it should be replaced with Libredirect which is very much updated almost weekly.

There's a Firefox version, and an Edge version. The Edge version is unfortunately taken down (falsely) by Microsoft due to "malware": https://github.com/libredirect/libredirect/issues/269