### PR TITLE
make trending accessible although feed is the default tab

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -28,6 +28,9 @@
         </div>
         <div class="flex-1 flex justify-end">
             <ul class="flex text-1xl children:pl-3">
+                <li v-if="shouldShowTrending">
+                    <router-link v-t="'titles.trending'" to="/trending" />
+                </li>
                 <li>
                     <router-link v-t="'titles.preferences'" to="/preferences" />
                 </li>
@@ -95,6 +98,9 @@ export default {
         },
         shouldShowHistory(_this) {
             return _this.getPreferenceBoolean("watchHistory", false);
+        },
+        shouldShowTrending(_this) {
+            return _this.getPreferenceString("homepage", "trending") != "trending";
         },
     },
     methods: {

--- a/src/components/TrendingPage.vue
+++ b/src/components/TrendingPage.vue
@@ -31,14 +31,17 @@ export default {
     activated() {
         document.title = this.$t("titles.trending") + " - Piped";
         if (this.videos.length > 0) this.updateWatched(this.videos);
-        switch (this.getPreferenceString("homepage", "trending")) {
-            case "trending":
-                break;
-            case "feed":
-                this.$router.push("/feed");
-                return;
-            default:
-                break;
+        console.log(this.$route.path);
+        if (this.$route.path == "/") {
+            switch (this.getPreferenceString("homepage", "trending")) {
+                case "trending":
+                    break;
+                case "feed":
+                    this.$router.push("/feed");
+                    return;
+                default:
+                    break;
+            }
         }
     },
     methods: {

--- a/src/components/TrendingPage.vue
+++ b/src/components/TrendingPage.vue
@@ -31,7 +31,6 @@ export default {
     activated() {
         document.title = this.$t("titles.trending") + " - Piped";
         if (this.videos.length > 0) this.updateWatched(this.videos);
-        console.log(this.$route.path);
         if (this.$route.path == "/") {
             switch (this.getPreferenceString("homepage", "trending")) {
                 case "trending":

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -3,6 +3,11 @@ import { createRouter, createWebHistory } from "vue-router";
 const routes = [
     {
         path: "/",
+        name: "Home",
+        component: () => import("../components/TrendingPage.vue"),
+    },
+    {
+        path: "/trending",
         name: "Trending",
         component: () => import("../components/TrendingPage.vue"),
     },


### PR DESCRIPTION
I don't know whether that's a good idea but it would allow users to browse the trending tab although they selected the feed as default tab. Currently there is no way to watch the trending videos when the default tab is set to feed.