### PR TITLE
Add Question template and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,16 @@
+name: Question
+description: Ask questions about configuration and usage of Piped.
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please make sure to read the README.md before posting a question or asking for support.
+        
+  - type: textarea
+    id: question
+    attributes:
+      label: Describe your question
+      description: A clear description of what your doubt is.
+    validations:
+      required: true


### PR DESCRIPTION
It appears that many people use a blank issue template for feature requests or bugs instead of the preconfigured templates, maybe to avoid having to fill out all the information.
The correct usage of issue templates makes it easier to replicate the bug or understand a suggestion and the reasons for it.
But that's only my personal opinion, I'm open for discussing it.