### PR TITLE
fix timestamp in share links

### DIFF
--- a/src/components/ShareModal.vue
+++ b/src/components/ShareModal.vue
@@ -69,11 +69,12 @@ export default {
     },
     computed: {
         generatedLink() {
-            var href = this.pipedLink
+            var baseUrl = this.pipedLink
                 ? window.location.origin + "/watch?v=" + this.videoId
                 : "https://youtu.be/" + this.videoId;
-            if (this.withTimeCode && this.timeStamp > 0) href += "?t=" + this.timeStamp;
-            return href;
+            var url = new URL(baseUrl);
+            if (this.withTimeCode && this.timeStamp > 0) url.searchParams.append("t", this.timeStamp);
+            return url.href;
         },
     },
 };


### PR DESCRIPTION
Piped links created via the share dialogue contain 2 query parameters, but both are prefixed with `?` instead of using `&` for subsequent parameters.
This wasn't an issue for YouTube links, since they don't use any other query parameters other than the timestamp.

To handle both cases, I used [`URL.searchParams.append()`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/append) in my solution.