### PR TITLE
Add proper whitespace to pinned comments

### DIFF
--- a/src/components/CommentItem.vue
+++ b/src/components/CommentItem.vue
@@ -14,6 +14,7 @@
                 <div v-if="comment.pinned" class="comment-pinned">
                     <font-awesome-icon icon="thumbtack" />
                     <span class="ml-1.5" v-t="'comment.pinned_by'" />
+                    <span>&nbsp;</span>
                     <span v-text="uploader" />
                 </div>
 


### PR DESCRIPTION
Currently the `pinned_by` message doesn't have proper whitespace.

Before:
![image](https://user-images.githubusercontent.com/81344401/195975453-77eed621-5912-48f0-a30f-3871762d0ac8.png)

After:
![image](https://user-images.githubusercontent.com/81344401/195975457-204070c1-41c4-4bcf-9bd7-440d6ae1d964.png)
