### PR TITLE
Fix setting of initial playback rate

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -519,9 +519,8 @@ export default {
                 });
                 videoEl.volume = this.getPreferenceNumber("volume", 1);
                 const rate = this.getPreferenceNumber("rate", 1);
-                player.trickPlay(rate);
-                player.playbackRate = rate;
-                player.defaultPlaybackRate = rate;
+                videoEl.playbackRate = rate;
+                videoEl.defaultPlaybackRate = rate;
             });
         },
         async updateProgressDatabase(time) {


### PR DESCRIPTION
Previously, *playbackRate* and *defaultPlaybackRate* were set on the `player` instead of the `videoEl`. Because of that, those settings were ignored and the `player.trickPlay` alone wasn't sufficient enough for the configuration to persist. After the fix, I removed the `player.trickPlay` call as it seemed redundant.

Related issues: #725, #842.