### PR TITLE
Allow timecode to be used as timestamp in Share Modal

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -128,7 +128,7 @@
         "piped_link": "Piped link",
         "follow_link": "Follow link",
         "copy_link": "Copy link",
-        "time_code": "Time code (in seconds)",
+        "time_code": "Time code (in seconds or HH:MM:SS)",
         "show_chapters": "Chapters",
         "store_search_history": "Store Search History",
         "hide_watched": "Hide watched videos in the feed",


### PR DESCRIPTION
Currently, the share modal only allows timestamp to be in seconds. This PR allows the timestamp to be in seconds as well as in `HH:MM:SS` format.

Some points to note:
- Currently, YouTube has a bit confusing of a policy about maximum video duration, as stated in #1672. Therefore, this PR parses the timecode string manually instead of using something like `Intl.DateFormat`.
- Currently, in the `HH:MM:SS` format, the seconds/minutes/hours value can be more than expected, which is handled without errors. For example: `10:61` will return `&t=661`. This can be changed if intended, but imo it's quite convenient.
- It would be required to update the `actions.time_code` translations to reflect the new changes.