### PR TITLE
Make numberFormat respect language and region settings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,12 @@ const mixin = {
             return str;
         },
         numberFormat(num) {
-            const formatter = Intl.NumberFormat(undefined, { notation: "compact" });
+            const formatter = Intl.NumberFormat(
+                `${this.getPreferenceString("hl")}-${this.getPreferenceString("region")}`,
+                {
+                    notation: "compact",
+                },
+            );
             return formatter.format(num);
         },
         addCommas(num) {


### PR DESCRIPTION
Currently,the numberFormat function will *always* use the fallback locale provided by Intl.NumberFormat. This PR tries to use the user's preferred language and region. If that fails, it will default to the fallback locale.