### PR TITLE
Don't load trending page on feed homepage

### DIFF
--- a/src/components/TrendingPage.vue
+++ b/src/components/TrendingPage.vue
@@ -21,6 +21,7 @@ export default {
         };
     },
     mounted() {
+        if (this.$route.path == "/" && this.getPreferenceString("homepage", "trending") == "feed") return;
         let region = this.getPreferenceString("region", "US");
 
         this.fetchTrending(region).then(videos => {


### PR DESCRIPTION
This prevents the trending data from being fetched unnecessarily before redirecting to the feed.