### PR TITLE
(Draft) Finer control for SponsorBlock

### DIFF
--- a/src/components/PreferencesPage.vue
+++ b/src/components/PreferencesPage.vue
@@ -185,63 +185,75 @@
     </label>
     <label class="pref" for="chkSkipSponsors">
         <strong v-t="'actions.skip_sponsors'" />
-        <input id="chkSkipSponsors" v-model="skipSponsor" class="checkbox" type="checkbox" @change="onChange($event)" />
+        <select id="chkSkipSponsors" v-model="skipSponsor" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipIntro">
         <strong v-t="'actions.skip_intro'" />
-        <input id="chkSkipIntro" v-model="skipIntro" class="checkbox" type="checkbox" @change="onChange($event)" />
+        <select id="chkSkipIntro" v-model="skipIntro" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipOutro">
         <strong v-t="'actions.skip_outro'" />
-        <input id="chkSkipOutro" v-model="skipOutro" class="checkbox" type="checkbox" @change="onChange($event)" />
+        <select id="chkSkipOutro" v-model="skipOutro" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipPreview">
         <strong v-t="'actions.skip_preview'" />
-        <input id="chkSkipPreview" v-model="skipPreview" class="checkbox" type="checkbox" @change="onChange($event)" />
+        <select id="chkSkipPreview" v-model="skipPreview" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipInteraction">
         <strong v-t="'actions.skip_interaction'" />
-        <input
-            id="chkSkipInteraction"
-            v-model="skipInteraction"
-            class="checkbox"
-            type="checkbox"
-            @change="onChange($event)"
-        />
+        <select id="chkSkipInteraction" v-model="skipInteraction" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipSelfPromo">
         <strong v-t="'actions.skip_self_promo'" />
-        <input
-            id="chkSkipSelfPromo"
-            v-model="skipSelfPromo"
-            class="checkbox"
-            type="checkbox"
-            @change="onChange($event)"
-        />
+        <select id="chkSkipSelfPromo" v-model="skipSelfPromo" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipNonMusic">
         <strong v-t="'actions.skip_non_music'" />
-        <input
-            id="chkSkipNonMusic"
-            v-model="skipMusicOffTopic"
-            class="checkbox"
-            type="checkbox"
-            @change="onChange($event)"
-        />
+        <select id="chkSkipNonMusic" v-model="skipMusicOffTopic" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipHighlight">
         <strong v-t="'actions.skip_highlight'" />
-        <input
-            id="chkSkipHighlight"
-            v-model="skipHighlight"
-            class="checkbox"
-            type="checkbox"
-            @change="onChange($event)"
-        />
+        <select id="chkSkipHighlight" v-model="skipHighlight" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkSkipFiller">
         <strong v-t="'actions.skip_filler_tangent'" />
-        <input id="chkSkipFiller" v-model="skipFiller" class="checkbox" type="checkbox" @change="onChange($event)" />
+        <select id="chkSkipFiller" v-model="skipFiller" @change="onChange($event)">
+            <option value="off">Disable</option>
+            <option value="skip">Auto Skip</option>
+            <option value="show">Show</option>
+        </select>
     </label>
     <label class="pref" for="chkShowMarkers">
         <strong v-t="'actions.show_markers'" />
@@ -470,7 +482,7 @@ export default {
 
             this.sponsorBlock = this.getPreferenceBoolean("sponsorblock", true);
             if (localStorage.getItem("selectedSkip") !== null) {
-                var skipList = localStorage.getItem("selectedSkip").split(",");
+                var skipList = JSON.parse(localStorage.getItem("selectedSkip"));
                 this.skipSponsor =
                     this.skipIntro =
                     this.skipOutro =
@@ -480,41 +492,41 @@ export default {
                     this.skipMusicOffTopic =
                     this.skipHighlight =
                     this.skipFiller =
-                        false;
-                skipList.forEach(skip => {
+                        "off";
+                for (const skip in skipList) {
                     switch (skip) {
                         case "sponsor":
-                            this.skipSponsor = true;
+                            this.skipSponsor = skipList[skip];
                             break;
                         case "intro":
-                            this.skipIntro = true;
+                            this.skipIntro = skipList[skip];
                             break;
                         case "outro":
-                            this.skipOutro = true;
+                            this.skipOutro = skipList[skip];
                             break;
                         case "preview":
-                            this.skipPreview = true;
+                            this.skipPreview = skipList[skip];
                             break;
                         case "interaction":
-                            this.skipInteraction = true;
+                            this.skipInteraction = skipList[skip];
                             break;
                         case "selfpromo":
-                            this.skipSelfPromo = true;
+                            this.skipSelfPromo = skipList[skip];
                             break;
                         case "music_offtopic":
-                            this.skipMusicOffTopic = true;
+                            this.skipMusicOffTopic = skipList[skip];
                             break;
                         case "poi_highlight":
-                            this.skipHighlight = true;
+                            this.skipHighlight = skipList[skip];
                             break;
                         case "filler":
-                            this.skipFiller = true;
+                            this.skipFiller = skipList[skip];
                             break;
                         default:
                             console.log("Unknown sponsor type: " + skip);
                             break;
                     }
-                });
+                }
             }
 
             this.showMarkers = this.getPreferenceBoolean("showMarkers", true);
@@ -566,17 +578,17 @@ export default {
                 localStorage.setItem("auth_instance_url", this.selectedAuthInstance);
                 localStorage.setItem("sponsorblock", this.sponsorBlock);
 
-                var sponsorSelected = [];
-                if (this.skipSponsor) sponsorSelected.push("sponsor");
-                if (this.skipIntro) sponsorSelected.push("intro");
-                if (this.skipOutro) sponsorSelected.push("outro");
-                if (this.skipPreview) sponsorSelected.push("preview");
-                if (this.skipInteraction) sponsorSelected.push("interaction");
-                if (this.skipSelfPromo) sponsorSelected.push("selfpromo");
-                if (this.skipMusicOffTopic) sponsorSelected.push("music_offtopic");
-                if (this.skipHighlight) sponsorSelected.push("poi_highlight");
-                if (this.skipFiller) sponsorSelected.push("filler");
-                localStorage.setItem("selectedSkip", sponsorSelected);
+                var sponsorSelected = {};
+                if (this.skipSponsor !== "off") sponsorSelected["sponsor"] = this.skipSponsor;
+                if (this.skipIntro !== "off") sponsorSelected["intro"] = this.skipIntro;
+                if (this.skipOutro !== "off") sponsorSelected["outro"] = this.skipOutro;
+                if (this.skipPreview !== "off") sponsorSelected["preview"] = this.skipPreview;
+                if (this.skipInteraction !== "off") sponsorSelected["interaction"] = this.skipInteraction;
+                if (this.skipSelfPromo !== "off") sponsorSelected["selfpromo"] = this.skipSelfPromo;
+                if (this.skipMusicOffTopic !== "off") sponsorSelected["music_offtopic"] = this.skipMusicOffTopic;
+                if (this.skipHighlight !== "off") sponsorSelected["poi_highlight"] = this.skipHighlight;
+                if (this.skipFiller !== "off") sponsorSelected["filler"] = this.skipFiller;
+                localStorage.setItem("selectedSkip", JSON.stringify(sponsorSelected));
 
                 localStorage.setItem("showMarkers", this.showMarkers);
                 localStorage.setItem("theme", this.selectedTheme);

--- a/src/components/PreferencesPage.vue
+++ b/src/components/PreferencesPage.vue
@@ -188,6 +188,7 @@
         <select id="chkSkipSponsors" v-model="skipSponsor" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -196,6 +197,7 @@
         <select id="chkSkipIntro" v-model="skipIntro" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -204,6 +206,7 @@
         <select id="chkSkipOutro" v-model="skipOutro" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -212,6 +215,7 @@
         <select id="chkSkipPreview" v-model="skipPreview" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -220,6 +224,7 @@
         <select id="chkSkipInteraction" v-model="skipInteraction" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -228,6 +233,7 @@
         <select id="chkSkipSelfPromo" v-model="skipSelfPromo" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -236,6 +242,7 @@
         <select id="chkSkipNonMusic" v-model="skipMusicOffTopic" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -244,6 +251,7 @@
         <select id="chkSkipHighlight" v-model="skipHighlight" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>
@@ -252,6 +260,7 @@
         <select id="chkSkipFiller" v-model="skipFiller" @change="onChange($event)">
             <option value="off">Disable</option>
             <option value="skip">Auto Skip</option>
+            <option value="manual">Manual Skip</option>
             <option value="show">Show</option>
         </select>
     </label>

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -361,8 +361,14 @@ export default {
                             if (!segment.skipped || this.selectedAutoLoop) {
                                 const end = segment.segment[1];
                                 if (time >= segment.segment[0] && time < end) {
-                                    console.log("Skipped segment at " + time);
-                                    videoEl.currentTime = end;
+                                    switch (this.getPreferenceDict("selectedSkip")[segment.category]) {
+                                        case "skip":
+                                            console.log("Skipped segment at " + time);
+                                            videoEl.currentTime = end;
+                                            break;
+                                        // show and off cases are do-nothing
+                                        // TODO: Manual skip
+                                    }
                                     segment.skipped = true;
                                     return;
                                 }

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -88,7 +88,7 @@ export default {
         this.hotkeysPromise.then(() => {
             var self = this;
             this.$hotkeys(
-                "f,m,j,k,l,c,space,up,down,left,right,0,1,2,3,4,5,6,7,8,9,shift+n,shift+,,shift+.",
+                "f,m,j,k,l,c,space,s,up,down,left,right,0,1,2,3,4,5,6,7,8,9,shift+n,shift+,,shift+.",
                 function (e, handler) {
                     const videoEl = self.$refs.videoEl;
                     switch (handler.key) {
@@ -117,6 +117,27 @@ export default {
                             if (videoEl.paused) videoEl.play();
                             else videoEl.pause();
                             e.preventDefault();
+                            break;
+                        case "s":
+                            {
+                                const time = videoEl.currentTime;
+                                const selectedSkip = self.getPreferenceDict("selectedSkip");
+                                if (self.sponsors && self.sponsors.segments) {
+                                    for (const segment of self.sponsors.segments) {
+                                        const end = segment.segment[1];
+                                        if (time >= segment.segment[0] && time < end) {
+                                            switch (selectedSkip[segment.category]) {
+                                                case "skip":
+                                                case "manual":
+                                                    console.log("Manually skipped segment at " + time);
+                                                    videoEl.currentTime = end;
+                                                    segment.skipped = true;
+                                                    return;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                             break;
                         case "up":
                             videoEl.volume = Math.min(videoEl.volume + 0.05, 1);
@@ -361,16 +382,11 @@ export default {
                             if (!segment.skipped || this.selectedAutoLoop) {
                                 const end = segment.segment[1];
                                 if (time >= segment.segment[0] && time < end) {
-                                    switch (this.getPreferenceDict("selectedSkip")[segment.category]) {
-                                        case "skip":
-                                            console.log("Skipped segment at " + time);
-                                            videoEl.currentTime = end;
-                                            break;
-                                        // show and off cases are do-nothing
-                                        // TODO: Manual skip
+                                    if (this.getPreferenceDict("selectedSkip")[segment.category] == "skip") {
+                                        console.log("Skipped segment at " + time);
+                                        videoEl.currentTime = end;
                                     }
                                     segment.skipped = true;
-                                    return;
                                 }
                             }
                         });

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -363,13 +363,11 @@ export default {
             return this.fetchJson(this.apiUrl() + "/streams/" + this.getVideoId());
         },
         async fetchSponsors() {
+            const skips = this.getPreferenceDict("selectedSkip", null);
             return await this.fetchJson(this.apiUrl() + "/sponsors/" + this.getVideoId(), {
                 category:
                     '["' +
-                    this.getPreferenceString("selectedSkip", "sponsor,interaction,selfpromo,music_offtopic").replaceAll(
-                        ",",
-                        '","',
-                    ) +
+                    (skips === null ? "sponsor,interaction,selfpromo,music_offtopic" : Object.keys(skips).join('","')) +
                     '"]',
             });
         },

--- a/src/main.js
+++ b/src/main.js
@@ -156,6 +156,15 @@ const mixin = {
                 return Number(value);
             } else return defaultVal;
         },
+        getPreferenceDict(key, defaultVal) {
+            var value;
+            if (
+                (value = new URLSearchParams(window.location.search).get(key)) !== null ||
+                (this.testLocalStorage && (value = localStorage.getItem(key)) !== null)
+            ) {
+                return JSON.parse(value);
+            } else return defaultVal;
+        },
         apiUrl() {
             return this.getPreferenceString("instance", "https://pipedapi.kavin.rocks");
         },


### PR DESCRIPTION
I'm not sure if I'll (be able to) finish this, but I thought I'd make a draft to see if this is considered feasible.

- [x] Preference page selection
- [x] Update sponsor fetching code
- [x] Show-only segments
- [x] Manual skip
- [ ] Manual skip popup
- [ ] Migration of preferences
- [ ] Vue componentization (broken attempt at https://github.com/photochlorination/Piped/tree/sponsorblock-vue-component)