### PR TITLE
Make timestamps in comments seek instead of reload

### DIFF
--- a/src/components/CommentItem.vue
+++ b/src/components/CommentItem.vue
@@ -71,6 +71,7 @@ export default {
         uploader: { type: String, default: null },
         videoId: { type: String, default: null },
     },
+    emits: ["seek"],
     data() {
         return {
             loadingReplies: false,
@@ -78,6 +79,21 @@ export default {
             replies: [],
             nextpage: null,
         };
+    },
+    mounted() {
+        const thisComment = this;
+        this.$el.querySelectorAll("a").forEach(elem => {
+            if (elem.innerText.match(/(?:[\d]{1,2}:)?(?:[\d]{1,2}):(?:[\d]{1,2})/)) {
+                elem.addEventListener("click", function (event) {
+                    if (!event || !event.target) return;
+                    if (!event.target.getAttribute("href").match(/(?<=t=)\d{1,}/)) return;
+
+                    const time = parseInt(event.target.getAttribute("href").match(/(?<=t=)\d{1,}/)[0]);
+                    thisComment.$emit("seek", time);
+                    event.preventDefault();
+                });
+            }
+        });
     },
     methods: {
         async loadReplies() {

--- a/src/components/CommentItem.vue
+++ b/src/components/CommentItem.vue
@@ -71,7 +71,6 @@ export default {
         uploader: { type: String, default: null },
         videoId: { type: String, default: null },
     },
-    emits: ["seek"],
     data() {
         return {
             loadingReplies: false,
@@ -79,21 +78,6 @@ export default {
             replies: [],
             nextpage: null,
         };
-    },
-    mounted() {
-        const thisComment = this;
-        this.$el.querySelectorAll("a").forEach(elem => {
-            if (elem.innerText.match(/(?:[\d]{1,2}:)?(?:[\d]{1,2}):(?:[\d]{1,2})/)) {
-                elem.addEventListener("click", function (event) {
-                    if (!event || !event.target) return;
-                    if (!event.target.getAttribute("href").match(/(?<=t=)\d{1,}/)) return;
-
-                    const time = parseInt(event.target.getAttribute("href").match(/(?<=t=)\d{1,}/)[0]);
-                    thisComment.$emit("seek", time);
-                    event.preventDefault();
-                });
-            }
-        });
     },
     methods: {
         async loadReplies() {

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -186,6 +186,7 @@
                     :comment="comment"
                     :uploader="video.uploader"
                     :video-id="getVideoId()"
+                    @seek="navigate"
                 />
             </div>
 

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -186,7 +186,6 @@
                     :comment="comment"
                     :uploader="video.uploader"
                     :video-id="getVideoId()"
-                    @seek="navigate"
                 />
             </div>
 
@@ -337,6 +336,19 @@ export default {
         this.getPlaylistData();
         this.getSponsors();
         if (!this.isEmbed && this.showComments) this.getComments();
+        window.addEventListener("click", event => {
+            if (!event || !event.target) return;
+            var target = event.target;
+            if (
+                !target.nodeName == "A" ||
+                !target.getAttribute("href") ||
+                !target.innerText.match(/(?:[\d]{1,2}:)?(?:[\d]{1,2}):(?:[\d]{1,2})/)
+            )
+                return;
+            const time = parseInt(event.target.getAttribute("href").match(/(?<=t=)\d+/)[0]);
+            this.navigate(time);
+            event.preventDefault();
+        });
         window.addEventListener("resize", () => {
             this.smallView = this.smallViewQuery.matches;
         });

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -345,7 +345,7 @@ export default {
                 !target.innerText.match(/(?:[\d]{1,2}:)?(?:[\d]{1,2}):(?:[\d]{1,2})/)
             )
                 return;
-            const time = parseInt(event.target.getAttribute("href").match(/(?<=t=)\d+/)[0]);
+            const time = parseInt(target.getAttribute("href").match(/(?<=t=)\d+/)[0]);
             this.navigate(time);
             event.preventDefault();
         });

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -336,19 +336,7 @@ export default {
         this.getPlaylistData();
         this.getSponsors();
         if (!this.isEmbed && this.showComments) this.getComments();
-        window.addEventListener("click", event => {
-            if (!event || !event.target) return;
-            var target = event.target;
-            if (
-                !target.nodeName == "A" ||
-                !target.getAttribute("href") ||
-                !target.innerText.match(/(?:[\d]{1,2}:)?(?:[\d]{1,2}):(?:[\d]{1,2})/)
-            )
-                return;
-            const time = parseInt(target.getAttribute("href").match(/(?<=t=)\d+/)[0]);
-            this.navigate(time);
-            event.preventDefault();
-        });
+        window.addEventListener("click", this.handleClick);
         window.addEventListener("resize", () => {
             this.smallView = this.smallViewQuery.matches;
         });
@@ -372,6 +360,7 @@ export default {
     },
     unmounted() {
         window.removeEventListener("scroll", this.handleScroll);
+        window.removeEventListener("click", this.handleClick);
     },
     methods: {
         fetchVideo() {
@@ -523,6 +512,19 @@ export default {
                 if (!this.handleLocalSubscriptions(this.channelId)) return;
             }
             this.subscribed = !this.subscribed;
+        },
+        handleClick(event) {
+            if (!event || !event.target) return;
+            var target = event.target;
+            if (
+                !target.nodeName == "A" ||
+                !target.getAttribute("href") ||
+                !target.innerText.match(/(?:[\d]{1,2}:)?(?:[\d]{1,2}):(?:[\d]{1,2})/)
+            )
+                return;
+            const time = parseInt(target.getAttribute("href").match(/(?<=t=)\d+/)[0]);
+            this.navigate(time);
+            event.preventDefault();
         },
         handleScroll() {
             if (this.loading || !this.comments || !this.comments.nextpage) return;


### PR DESCRIPTION
Small quality of life improvement. This will make clicking timestamps posted as `HH:MM:SS` (or `MM:SS`) in the comments seek the video to the correct place instead of reloading the page with a `&t=ssss` parameter, similar to the chapter bar. The links can still be copied via right click and opened in a new tab as usual.

Example video without chapters: https://piped.video/watch?v=cVFzblT5VPE, see tracklist comment.