### PR TITLE
Support for exporting the watch history as playlist

### DIFF
--- a/src/components/HistoryPage.vue
+++ b/src/components/HistoryPage.vue
@@ -4,6 +4,8 @@
     <div class="flex">
         <div>
             <button class="btn" v-t="'actions.clear_history'" @click="clearHistory" />
+
+            <button class="btn mx-3" v-t="'actions.export_to_json'" @click="exportHistory" />
         </div>
 
         <div class="right-1">
@@ -70,6 +72,22 @@ export default {
                 store.clear();
             }
             this.videos = [];
+        },
+        exportHistory() {
+            const dateStr = new Date().toISOString().split(".")[0];
+            let json = {
+                format: "Piped",
+                version: 1,
+                playlists: [
+                    {
+                        name: `Piped History ${dateStr}`,
+                        type: "history",
+                        visibility: "private",
+                        videos: this.videos.map(video => "https://youtube.com" + video.url),
+                    },
+                ],
+            };
+            this.download(JSON.stringify(json), `piped_history_${dateStr}.json`, "application/json");
         },
     },
 };

--- a/src/main.js
+++ b/src/main.js
@@ -241,8 +241,8 @@ const mixin = {
             return localSubscriptions.join(",");
         },
         /* generate a temporary file and ask the user to download it */
-        download(text, filename, type) {
-            var file = new Blob([text], { type: type });
+        download(text, filename, mimeType) {
+            var file = new Blob([text], { type: mimeType });
 
             const elem = document.createElement("a");
 


### PR DESCRIPTION
This PR allows users to export their watch history to a json file.
The format used is the same as for playlists, thus it can then be imported as a playlist.
I wasn't sure whether it's better to use a completely different format containing all the history items or to only store the video IDs and fetch all the videos again when importing, which I decided to do because having multiple different formats would probably result in a mess.
However, this PR does not yet contain a possibility to re-import the exported watch history as I wanted to hear a different opinion on that topic first.

addresses #1514 