### PR TITLE
Add more options for sponsorblock

### DIFF
--- a/src/components/PreferencesPage.vue
+++ b/src/components/PreferencesPage.vue
@@ -184,83 +184,77 @@
         />
     </label>
     <div v-if="sponsorBlock">
-        <label class="pref" for="chkSkipSponsors">
+        <label class="pref" for="ddlSkipSponsors">
             <strong v-t="'actions.skip_sponsors'" />
-            <input
-                id="chkSkipSponsors"
-                v-model="skipSponsor"
-                class="checkbox"
-                type="checkbox"
-                @change="onChange($event)"
-            />
+            <select id="ddlSkipSponsors" v-model="skipSponsor" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipIntro">
+        <label class="pref" for="ddlSkipIntro">
             <strong v-t="'actions.skip_intro'" />
-            <input id="chkSkipIntro" v-model="skipIntro" class="checkbox" type="checkbox" @change="onChange($event)" />
+            <select id="ddlSkipIntro" v-model="skipIntro" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipOutro">
+        <label class="pref" for="ddlSkipOutro">
             <strong v-t="'actions.skip_outro'" />
-            <input id="chkSkipOutro" v-model="skipOutro" class="checkbox" type="checkbox" @change="onChange($event)" />
+            <select id="ddlSkipOutro" v-model="skipOutro" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipPreview">
+        <label class="pref" for="ddlSkipPreview">
             <strong v-t="'actions.skip_preview'" />
-            <input
-                id="chkSkipPreview"
-                v-model="skipPreview"
-                class="checkbox"
-                type="checkbox"
-                @change="onChange($event)"
-            />
+            <select id="ddlSkipPreview" v-model="skipPreview" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipInteraction">
+        <label class="pref" for="ddlSkipInteraction">
             <strong v-t="'actions.skip_interaction'" />
-            <input
-                id="chkSkipInteraction"
-                v-model="skipInteraction"
-                class="checkbox"
-                type="checkbox"
-                @change="onChange($event)"
-            />
+            <select id="ddlSkipInteraction" v-model="skipInteraction" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipSelfPromo">
+        <label class="pref" for="ddlSkipSelfPromo">
             <strong v-t="'actions.skip_self_promo'" />
-            <input
-                id="chkSkipSelfPromo"
-                v-model="skipSelfPromo"
-                class="checkbox"
-                type="checkbox"
-                @change="onChange($event)"
-            />
+            <select id="ddlSkipSelfPromo" v-model="skipSelfPromo" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipNonMusic">
+        <label class="pref" for="ddlSkipNonMusic">
             <strong v-t="'actions.skip_non_music'" />
-            <input
-                id="chkSkipNonMusic"
-                v-model="skipMusicOffTopic"
-                class="checkbox"
-                type="checkbox"
-                @change="onChange($event)"
-            />
+            <select id="ddlSkipNonMusic" v-model="skipMusicOffTopic" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipHighlight">
+        <label class="pref" for="ddlSkipHighlight">
             <strong v-t="'actions.skip_highlight'" />
-            <input
-                id="chkSkipHighlight"
-                v-model="skipHighlight"
-                class="checkbox"
-                type="checkbox"
-                @change="onChange($event)"
-            />
+            <select id="ddlSkipHighlight" v-model="skipHighlight" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
-        <label class="pref" for="chkSkipFiller">
+        <label class="pref" for="ddlSkipFiller">
             <strong v-t="'actions.skip_filler_tangent'" />
-            <input
-                id="chkSkipFiller"
-                v-model="skipFiller"
-                class="checkbox"
-                type="checkbox"
-                @change="onChange($event)"
-            />
+            <select id="ddlSkipFiller" v-model="skipFiller" class="select w-auto" @change="onChange($event)">
+                <option v-t="'actions.no'" value="no" />
+                <option v-t="'actions.skip_button_only'" value="button" />
+                <option v-t="'actions.skip_automatically'" value="auto" />
+            </select>
         </label>
         <label class="pref" for="chkShowMarkers">
             <strong v-t="'actions.show_markers'" />
@@ -391,15 +385,15 @@ export default {
             selectedAuthInstance: null,
             instances: [],
             sponsorBlock: true,
-            skipSponsor: true,
-            skipIntro: false,
-            skipOutro: false,
-            skipPreview: false,
-            skipInteraction: true,
-            skipSelfPromo: true,
-            skipMusicOffTopic: true,
-            skipHighlight: false,
-            skipFiller: false,
+            skipSponsor: "auto",
+            skipIntro: "no",
+            skipOutro: "no",
+            skipPreview: "no",
+            skipInteraction: "auto",
+            skipSelfPromo: "auto",
+            skipMusicOffTopic: "auto",
+            skipHighlight: "no",
+            skipFiller: "no",
             showMarkers: true,
             selectedTheme: "dark",
             autoPlayVideo: true,
@@ -497,7 +491,18 @@ export default {
             this.selectedAuthInstance = this.getPreferenceString("auth_instance_url", this.selectedInstance);
 
             this.sponsorBlock = this.getPreferenceBoolean("sponsorblock", true);
-            if (localStorage.getItem("selectedSkip") !== null) {
+            if (localStorage.getItem("skipOptions") !== null) {
+                const skipOptions = JSON.parse(localStorage.getItem("skipOptions"));
+                if (skipOptions.sponsor !== undefined) this.skipSponsor = skipOptions.sponsor;
+                if (skipOptions.intro !== undefined) this.skipIntro = skipOptions.intro;
+                if (skipOptions.outro !== undefined) this.skipOutro = skipOptions.outro;
+                if (skipOptions.preview !== undefined) this.skipPreview = skipOptions.preview;
+                if (skipOptions.interaction !== undefined) this.skipInteraction = skipOptions.interaction;
+                if (skipOptions.selfpromo !== undefined) this.skipSelfPromo = skipOptions.selfpromo;
+                if (skipOptions.music_offtopic !== undefined) this.skipMusicOffTopic = skipOptions.music_offtopic;
+                if (skipOptions.poi_highlight !== undefined) this.skipHighlight = skipOptions.poi_highlight;
+                if (skipOptions.filler !== undefined) this.skipFiller = skipOptions.filler;
+            } else if (localStorage.getItem("selectedSkip") !== null) {
                 var skipList = localStorage.getItem("selectedSkip").split(",");
                 this.skipSponsor =
                     this.skipIntro =
@@ -508,35 +513,35 @@ export default {
                     this.skipMusicOffTopic =
                     this.skipHighlight =
                     this.skipFiller =
-                        false;
+                        "no";
                 skipList.forEach(skip => {
                     switch (skip) {
                         case "sponsor":
-                            this.skipSponsor = true;
+                            this.skipSponsor = "auto";
                             break;
                         case "intro":
-                            this.skipIntro = true;
+                            this.skipIntro = "auto";
                             break;
                         case "outro":
-                            this.skipOutro = true;
+                            this.skipOutro = "auto";
                             break;
                         case "preview":
-                            this.skipPreview = true;
+                            this.skipPreview = "auto";
                             break;
                         case "interaction":
-                            this.skipInteraction = true;
+                            this.skipInteraction = "auto";
                             break;
                         case "selfpromo":
-                            this.skipSelfPromo = true;
+                            this.skipSelfPromo = "auto";
                             break;
                         case "music_offtopic":
-                            this.skipMusicOffTopic = true;
+                            this.skipMusicOffTopic = "auto";
                             break;
                         case "poi_highlight":
-                            this.skipHighlight = true;
+                            this.skipHighlight = "auto";
                             break;
                         case "filler":
-                            this.skipFiller = true;
+                            this.skipFiller = "auto";
                             break;
                         default:
                             console.log("Unknown sponsor type: " + skip);
@@ -594,17 +599,18 @@ export default {
                 localStorage.setItem("auth_instance_url", this.selectedAuthInstance);
                 localStorage.setItem("sponsorblock", this.sponsorBlock);
 
-                var sponsorSelected = [];
-                if (this.skipSponsor) sponsorSelected.push("sponsor");
-                if (this.skipIntro) sponsorSelected.push("intro");
-                if (this.skipOutro) sponsorSelected.push("outro");
-                if (this.skipPreview) sponsorSelected.push("preview");
-                if (this.skipInteraction) sponsorSelected.push("interaction");
-                if (this.skipSelfPromo) sponsorSelected.push("selfpromo");
-                if (this.skipMusicOffTopic) sponsorSelected.push("music_offtopic");
-                if (this.skipHighlight) sponsorSelected.push("poi_highlight");
-                if (this.skipFiller) sponsorSelected.push("filler");
-                localStorage.setItem("selectedSkip", sponsorSelected);
+                const skipOptions = {
+                    sponsor: this.skipSponsor,
+                    intro: this.skipIntro,
+                    outro: this.skipOutro,
+                    preview: this.skipPreview,
+                    interaction: this.skipInteraction,
+                    selfpromo: this.skipSelfPromo,
+                    music_offtopic: this.skipMusicOffTopic,
+                    poi_highlight: this.skipHighlight,
+                    filler: this.skipFiller,
+                };
+                localStorage.setItem("skipOptions", JSON.stringify(skipOptions));
 
                 localStorage.setItem("showMarkers", this.showMarkers);
                 localStorage.setItem("theme", this.selectedTheme);

--- a/src/components/PreferencesPage.vue
+++ b/src/components/PreferencesPage.vue
@@ -184,73 +184,9 @@
         />
     </label>
     <div v-if="sponsorBlock">
-        <label class="pref" for="ddlSkipSponsors">
-            <strong v-t="'actions.skip_sponsors'" />
-            <select id="ddlSkipSponsors" v-model="skipSponsor" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipIntro">
-            <strong v-t="'actions.skip_intro'" />
-            <select id="ddlSkipIntro" v-model="skipIntro" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipOutro">
-            <strong v-t="'actions.skip_outro'" />
-            <select id="ddlSkipOutro" v-model="skipOutro" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipPreview">
-            <strong v-t="'actions.skip_preview'" />
-            <select id="ddlSkipPreview" v-model="skipPreview" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipInteraction">
-            <strong v-t="'actions.skip_interaction'" />
-            <select id="ddlSkipInteraction" v-model="skipInteraction" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipSelfPromo">
-            <strong v-t="'actions.skip_self_promo'" />
-            <select id="ddlSkipSelfPromo" v-model="skipSelfPromo" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipNonMusic">
-            <strong v-t="'actions.skip_non_music'" />
-            <select id="ddlSkipNonMusic" v-model="skipMusicOffTopic" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipHighlight">
-            <strong v-t="'actions.skip_highlight'" />
-            <select id="ddlSkipHighlight" v-model="skipHighlight" class="select w-auto" @change="onChange($event)">
-                <option v-t="'actions.no'" value="no" />
-                <option v-t="'actions.skip_button_only'" value="button" />
-                <option v-t="'actions.skip_automatically'" value="auto" />
-            </select>
-        </label>
-        <label class="pref" for="ddlSkipFiller">
-            <strong v-t="'actions.skip_filler_tangent'" />
-            <select id="ddlSkipFiller" v-model="skipFiller" class="select w-auto" @change="onChange($event)">
+        <label v-for="[name, item] in skipOptions" class="pref" :for="'ddlSkip_' + name" :key="name">
+            <strong v-t="item.label" />
+            <select :id="'ddlSkip_' + name" v-model="item.value" class="select w-auto" @change="onChange($event)">
                 <option v-t="'actions.no'" value="no" />
                 <option v-t="'actions.skip_button_only'" value="button" />
                 <option v-t="'actions.skip_automatically'" value="auto" />
@@ -395,15 +331,17 @@ export default {
             selectedAuthInstance: null,
             instances: [],
             sponsorBlock: true,
-            skipSponsor: "auto",
-            skipIntro: "no",
-            skipOutro: "no",
-            skipPreview: "no",
-            skipInteraction: "auto",
-            skipSelfPromo: "auto",
-            skipMusicOffTopic: "auto",
-            skipHighlight: "no",
-            skipFiller: "no",
+            skipOptions: new Map([
+                ["sponsor", { value: "auto", label: "actions.skip_sponsors" }],
+                ["intro", { value: "no", label: "actions.skip_intro" }],
+                ["outro", { value: "no", label: "actions.skip_outro" }],
+                ["preview", { value: "no", label: "actions.skip_preview" }],
+                ["interaction", { value: "auto", label: "actions.skip_interaction" }],
+                ["selfpromo", { value: "auto", label: "actions.skip_self_promo" }],
+                ["music_offtopic", { value: "auto", label: "actions.skip_non_music" }],
+                ["poi_highlight", { value: "no", label: "actions.skip_highlight" }],
+                ["filler", { value: "no", label: "actions.skip_filler_tangent" }],
+            ]),
             showMarkers: true,
             minSegmentLength: 0,
             selectedTheme: "dark",
@@ -504,60 +442,18 @@ export default {
             this.sponsorBlock = this.getPreferenceBoolean("sponsorblock", true);
             var skipOptions, skipList;
             if ((skipOptions = this.getPreferenceJSON("skipOptions")) !== undefined) {
-                if (skipOptions.sponsor !== undefined) this.skipSponsor = skipOptions.sponsor;
-                if (skipOptions.intro !== undefined) this.skipIntro = skipOptions.intro;
-                if (skipOptions.outro !== undefined) this.skipOutro = skipOptions.outro;
-                if (skipOptions.preview !== undefined) this.skipPreview = skipOptions.preview;
-                if (skipOptions.interaction !== undefined) this.skipInteraction = skipOptions.interaction;
-                if (skipOptions.selfpromo !== undefined) this.skipSelfPromo = skipOptions.selfpromo;
-                if (skipOptions.music_offtopic !== undefined) this.skipMusicOffTopic = skipOptions.music_offtopic;
-                if (skipOptions.poi_highlight !== undefined) this.skipHighlight = skipOptions.poi_highlight;
-                if (skipOptions.filler !== undefined) this.skipFiller = skipOptions.filler;
+                Object.entries(skipOptions).forEach(([key, value]) => {
+                    var opt = this.skipOptions.get(key);
+                    if (opt !== undefined) opt.value = value;
+                    else console.log("Unknown sponsor type: " + key);
+                });
             } else if ((skipList = this.getPreferenceString("selectedSkip")) !== undefined) {
                 skipList = skipList.split(",");
-                this.skipSponsor =
-                    this.skipIntro =
-                    this.skipOutro =
-                    this.skipPreview =
-                    this.skipInteraction =
-                    this.skipSelfPromo =
-                    this.skipMusicOffTopic =
-                    this.skipHighlight =
-                    this.skipFiller =
-                        "no";
+                this.skipOptions.forEach(opt => (opt.value = "no"));
                 skipList.forEach(skip => {
-                    switch (skip) {
-                        case "sponsor":
-                            this.skipSponsor = "auto";
-                            break;
-                        case "intro":
-                            this.skipIntro = "auto";
-                            break;
-                        case "outro":
-                            this.skipOutro = "auto";
-                            break;
-                        case "preview":
-                            this.skipPreview = "auto";
-                            break;
-                        case "interaction":
-                            this.skipInteraction = "auto";
-                            break;
-                        case "selfpromo":
-                            this.skipSelfPromo = "auto";
-                            break;
-                        case "music_offtopic":
-                            this.skipMusicOffTopic = "auto";
-                            break;
-                        case "poi_highlight":
-                            this.skipHighlight = "auto";
-                            break;
-                        case "filler":
-                            this.skipFiller = "auto";
-                            break;
-                        default:
-                            console.log("Unknown sponsor type: " + skip);
-                            break;
-                    }
+                    var opt = this.skipOptions.get(skip);
+                    if (opt !== undefined) opt.value = "auto";
+                    else console.log("Unknown sponsor type: " + skip);
                 });
             }
 
@@ -611,17 +507,8 @@ export default {
                 localStorage.setItem("auth_instance_url", this.selectedAuthInstance);
                 localStorage.setItem("sponsorblock", this.sponsorBlock);
 
-                const skipOptions = {
-                    sponsor: this.skipSponsor,
-                    intro: this.skipIntro,
-                    outro: this.skipOutro,
-                    preview: this.skipPreview,
-                    interaction: this.skipInteraction,
-                    selfpromo: this.skipSelfPromo,
-                    music_offtopic: this.skipMusicOffTopic,
-                    poi_highlight: this.skipHighlight,
-                    filler: this.skipFiller,
-                };
+                var skipOptions = {};
+                this.skipOptions.forEach((v, k) => (skipOptions[k] = v.value));
                 localStorage.setItem("skipOptions", JSON.stringify(skipOptions));
 
                 localStorage.setItem("showMarkers", this.showMarkers);

--- a/src/components/PreferencesPage.vue
+++ b/src/components/PreferencesPage.vue
@@ -503,7 +503,7 @@ export default {
 
             this.sponsorBlock = this.getPreferenceBoolean("sponsorblock", true);
             var skipOptions, skipList;
-            if ((skipOptions = this.getPreferenceJSON("skipOptions")) !== null) {
+            if ((skipOptions = this.getPreferenceJSON("skipOptions")) !== undefined) {
                 if (skipOptions.sponsor !== undefined) this.skipSponsor = skipOptions.sponsor;
                 if (skipOptions.intro !== undefined) this.skipIntro = skipOptions.intro;
                 if (skipOptions.outro !== undefined) this.skipOutro = skipOptions.outro;
@@ -513,7 +513,7 @@ export default {
                 if (skipOptions.music_offtopic !== undefined) this.skipMusicOffTopic = skipOptions.music_offtopic;
                 if (skipOptions.poi_highlight !== undefined) this.skipHighlight = skipOptions.poi_highlight;
                 if (skipOptions.filler !== undefined) this.skipFiller = skipOptions.filler;
-            } else if ((skipList = this.getPreferenceString("selectedSkip")) !== null) {
+            } else if ((skipList = this.getPreferenceString("selectedSkip")) !== undefined) {
                 skipList = skipList.split(",");
                 this.skipSponsor =
                     this.skipIntro =

--- a/src/components/PreferencesPage.vue
+++ b/src/components/PreferencesPage.vue
@@ -502,8 +502,8 @@ export default {
             this.selectedAuthInstance = this.getPreferenceString("auth_instance_url", this.selectedInstance);
 
             this.sponsorBlock = this.getPreferenceBoolean("sponsorblock", true);
-            if (localStorage.getItem("skipOptions") !== null) {
-                const skipOptions = JSON.parse(localStorage.getItem("skipOptions"));
+            var skipOptions, skipList;
+            if ((skipOptions = this.getPreferenceJSON("skipOptions")) !== null) {
                 if (skipOptions.sponsor !== undefined) this.skipSponsor = skipOptions.sponsor;
                 if (skipOptions.intro !== undefined) this.skipIntro = skipOptions.intro;
                 if (skipOptions.outro !== undefined) this.skipOutro = skipOptions.outro;
@@ -513,8 +513,8 @@ export default {
                 if (skipOptions.music_offtopic !== undefined) this.skipMusicOffTopic = skipOptions.music_offtopic;
                 if (skipOptions.poi_highlight !== undefined) this.skipHighlight = skipOptions.poi_highlight;
                 if (skipOptions.filler !== undefined) this.skipFiller = skipOptions.filler;
-            } else if (localStorage.getItem("selectedSkip") !== null) {
-                var skipList = localStorage.getItem("selectedSkip").split(",");
+            } else if ((skipList = this.getPreferenceString("selectedSkip")) !== null) {
+                skipList = skipList.split(",");
                 this.skipSponsor =
                     this.skipIntro =
                     this.skipOutro =
@@ -562,7 +562,7 @@ export default {
             }
 
             this.showMarkers = this.getPreferenceBoolean("showMarkers", true);
-            this.minSegmentLength = Math.max(Number(localStorage.getItem("minSegmentLength")), 0);
+            this.minSegmentLength = Math.max(this.getPreferenceNumber("minSegmentLength", 0), 0);
             this.selectedTheme = this.getPreferenceString("theme", "dark");
             this.autoPlayVideo = this.getPreferenceBoolean("playerAutoPlay", true);
             this.listen = this.getPreferenceBoolean("listen", false);

--- a/src/components/PreferencesPage.vue
+++ b/src/components/PreferencesPage.vue
@@ -266,6 +266,16 @@
                 @change="onChange($event)"
             />
         </label>
+        <label class="pref" for="txtMinSegmentLength">
+            <strong v-t="'actions.min_segment_length'" />
+            <input
+                id="txtMinSegmentLength"
+                v-model="minSegmentLength"
+                class="input w-24"
+                type="text"
+                @change="onChange($event)"
+            />
+        </label>
     </div>
     <h2 class="text-center" v-t="'titles.instance'" />
     <label class="pref" for="ddlInstanceSelection">
@@ -395,6 +405,7 @@ export default {
             skipHighlight: "no",
             skipFiller: "no",
             showMarkers: true,
+            minSegmentLength: 0,
             selectedTheme: "dark",
             autoPlayVideo: true,
             listen: false,
@@ -551,6 +562,7 @@ export default {
             }
 
             this.showMarkers = this.getPreferenceBoolean("showMarkers", true);
+            this.minSegmentLength = Math.max(Number(localStorage.getItem("minSegmentLength")), 0);
             this.selectedTheme = this.getPreferenceString("theme", "dark");
             this.autoPlayVideo = this.getPreferenceBoolean("playerAutoPlay", true);
             this.listen = this.getPreferenceBoolean("listen", false);
@@ -613,6 +625,7 @@ export default {
                 localStorage.setItem("skipOptions", JSON.stringify(skipOptions));
 
                 localStorage.setItem("showMarkers", this.showMarkers);
+                localStorage.setItem("minSegmentLength", this.minSegmentLength);
                 localStorage.setItem("theme", this.selectedTheme);
                 localStorage.setItem("playerAutoPlay", this.autoPlayVideo);
                 localStorage.setItem("listen", this.listen);

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -750,7 +750,7 @@ export default {
     },
     watch: {
         sponsors() {
-            const skipOptions = JSON.parse(this.getPreferenceString("skipOptions", "{}"));
+            const skipOptions = this.getPreferenceJSON("skipOptions", {});
             this.sponsors?.segments?.forEach(segment => {
                 const option = skipOptions[segment.category];
                 segment.autoskip = option === undefined || option === "auto";

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -88,7 +88,7 @@ export default {
         this.hotkeysPromise.then(() => {
             var self = this;
             this.$hotkeys(
-                "f,m,j,k,l,c,space,up,down,left,right,0,1,2,3,4,5,6,7,8,9,shift+n,shift+,,shift+.",
+                "f,m,j,k,l,c,space,up,down,left,right,0,1,2,3,4,5,6,7,8,9,shift+n,shift+,,shift+.,return",
                 function (e, handler) {
                     const videoEl = self.$refs.videoEl;
                     switch (handler.key) {
@@ -183,6 +183,9 @@ export default {
                             break;
                         case "shift+.":
                             self.$player.trickPlay(Math.min(videoEl.playbackRate + 0.25, 2));
+                            break;
+                        case "return":
+                            self.skipSegment(videoEl);
                             break;
                     }
                 },
@@ -361,17 +364,16 @@ export default {
                     this.$emit("timeupdate", time);
                     this.updateProgressDatabase(time);
                     if (this.sponsors && this.sponsors.segments) {
-                        this.sponsors.segments.map(segment => {
-                            if (!segment.skipped || this.selectedAutoLoop) {
-                                const end = segment.segment[1];
-                                if (time >= segment.segment[0] && time < end) {
-                                    console.log("Skipped segment at " + time);
-                                    videoEl.currentTime = end;
-                                    segment.skipped = true;
-                                    return;
-                                }
-                            }
+                        const segment = this.findCurrentSegment(time);
+                        const segmentUpdate = new CustomEvent("segmentupdate", {
+                            detail: {
+                                inSegment: !!segment,
+                            },
                         });
+                        videoEl.dispatchEvent(segmentUpdate);
+                        if (segment?.autoskip && (!segment.skipped || this.selectedAutoLoop)) {
+                            this.skipSegment(videoEl, segment);
+                        }
                     }
                 });
 
@@ -397,6 +399,17 @@ export default {
             }
 
             //TODO: Add sponsors on seekbar: https://github.com/ajayyy/SponsorBlock/blob/e39de9fd852adb9196e0358ed827ad38d9933e29/src/js-components/previewBar.ts#L12
+        },
+        findCurrentSegment(time) {
+            return this.sponsors?.segments?.find(s => time >= s.segment[0] && time < s.segment[1]);
+        },
+        skipSegment(videoEl, segment) {
+            const time = videoEl.currentTime;
+            if (!segment) segment = this.findCurrentSegment(time);
+            if (!segment) return;
+            console.log("Skipped segment at " + time);
+            videoEl.currentTime = segment.segment[1];
+            segment.skipped = true;
         },
         setPlayerAttrs(localPlayer, videoEl, uri, mime, shaka) {
             const url = "/watch?v=" + this.video.id;
@@ -442,6 +455,54 @@ export default {
 
                 shaka.ui.OverflowMenu.registerElement("open_new_tab", new OpenButton.Factory());
 
+                const videoPlayerComponent = this;
+
+                const SkipSegmentButton = class extends shaka.ui.Element {
+                    constructor(parent, controls) {
+                        super(parent, controls);
+
+                        // FIXME: this layout is by no means final,
+                        // I just needed something to test with.
+                        this.button_ = document.createElement("button");
+                        this.button_.classList.add("shaka-small-play-button");
+                        this.button_.classList.add("shaka-tooltip");
+                        this.button_.classList.add("shaka-hidden");
+                        this.button_.ariaPressed = "false";
+
+                        this.icon_ = document.createElement("i");
+                        this.icon_.classList.add("material-icons-round");
+                        this.icon_.textContent = "skip_next";
+                        this.button_.appendChild(this.icon_);
+
+                        const label = document.createElement("label");
+                        this.newTabNameSpan_ = document.createElement("span");
+                        this.newTabNameSpan_.classList.add("shaka-current-time");
+                        this.newTabNameSpan_.innerText = "Skip segment";
+                        label.appendChild(this.newTabNameSpan_);
+
+                        this.button_.appendChild(label);
+                        this.parent.appendChild(this.button_);
+
+                        this.eventManager.listen(this.button_, "click", () => {
+                            videoPlayerComponent.skipSegment(videoEl);
+                        });
+
+                        videoEl.addEventListener("segmentupdate", e => {
+                            const inSegment = e.detail.inSegment;
+                            if (inSegment) this.button_.classList.remove("shaka-hidden");
+                            else this.button_.classList.add("shaka-hidden");
+                        });
+                    }
+                };
+
+                SkipSegmentButton.Factory = class {
+                    create(rootElement, controls) {
+                        return new SkipSegmentButton(rootElement, controls);
+                    }
+                };
+
+                shaka.ui.Controls.registerElement("skip_segment", new SkipSegmentButton.Factory());
+
                 this.$ui = new shaka.ui.Overlay(localPlayer, this.$refs.container, videoEl);
 
                 const overflowMenuButtons = [
@@ -458,6 +519,17 @@ export default {
                 }
 
                 const config = {
+                    controlPanelElements: [
+                        "play_pause",
+                        "time_and_duration",
+                        "spacer",
+                        "skip_segment",
+                        "spacer",
+                        "mute",
+                        "volume",
+                        "fullscreen",
+                        "overflow_menu",
+                    ],
                     overflowMenuButtons: overflowMenuButtons,
                     seekBarColors: {
                         base: "rgba(255, 255, 255, 0.3)",
@@ -678,6 +750,11 @@ export default {
     },
     watch: {
         sponsors() {
+            const skipOptions = JSON.parse(this.getPreferenceString("skipOptions", "{}"));
+            this.sponsors?.segments?.forEach(segment => {
+                const option = skipOptions[segment.category];
+                segment.autoskip = option === undefined || option === "auto";
+            });
             if (this.getPreferenceBoolean("showMarkers", true)) {
                 this.shakaPromise.then(() => {
                     this.updateMarkers();

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -367,14 +367,20 @@ export default {
             return this.fetchJson(this.apiUrl() + "/streams/" + this.getVideoId());
         },
         async fetchSponsors() {
+            var selectedSkip = this.getPreferenceString(
+                "selectedSkip",
+                "sponsor,interaction,selfpromo,music_offtopic",
+            ).split(",");
+            const skipOptionsJSON = localStorage.getItem("skipOptions");
+            if (skipOptionsJSON !== null) {
+                const skipOptions = JSON.parse(skipOptionsJSON);
+                selectedSkip = Object.keys(skipOptions).filter(
+                    k => skipOptions[k] !== undefined && skipOptions[k] !== "no",
+                );
+            }
+
             return await this.fetchJson(this.apiUrl() + "/sponsors/" + this.getVideoId(), {
-                category:
-                    '["' +
-                    this.getPreferenceString("selectedSkip", "sponsor,interaction,selfpromo,music_offtopic").replaceAll(
-                        ",",
-                        '","',
-                    ) +
-                    '"]',
+                category: JSON.stringify(selectedSkip),
             });
         },
         toggleComments() {

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -372,7 +372,7 @@ export default {
                 "sponsor,interaction,selfpromo,music_offtopic",
             ).split(",");
             const skipOptions = this.getPreferenceJSON("skipOptions");
-            if (skipOptions !== null) {
+            if (skipOptions !== undefined) {
                 selectedSkip = Object.keys(skipOptions).filter(
                     k => skipOptions[k] !== undefined && skipOptions[k] !== "no",
                 );

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -379,9 +379,17 @@ export default {
                 );
             }
 
-            return await this.fetchJson(this.apiUrl() + "/sponsors/" + this.getVideoId(), {
+            const sponsors = await this.fetchJson(this.apiUrl() + "/sponsors/" + this.getVideoId(), {
                 category: JSON.stringify(selectedSkip),
             });
+
+            const minSegmentLength = Math.max(this.getPreferenceNumber("minSegmentLength", 0), 0);
+            sponsors.segments = sponsors.segments.filter(segment => {
+                const length = segment.segment[1] - segment.segment[0];
+                return length >= minSegmentLength;
+            });
+
+            return sponsors;
         },
         toggleComments() {
             this.showComments = !this.showComments;

--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -371,9 +371,8 @@ export default {
                 "selectedSkip",
                 "sponsor,interaction,selfpromo,music_offtopic",
             ).split(",");
-            const skipOptionsJSON = localStorage.getItem("skipOptions");
-            if (skipOptionsJSON !== null) {
-                const skipOptions = JSON.parse(skipOptionsJSON);
+            const skipOptions = this.getPreferenceJSON("skipOptions");
+            if (skipOptions !== null) {
                 selectedSkip = Object.keys(skipOptions).filter(
                     k => skipOptions[k] !== undefined && skipOptions[k] !== "no",
                 );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,6 +30,8 @@
         "back": "Back",
         "uses_api_from": "Uses the API from ",
         "enable_sponsorblock": "Enable Sponsorblock",
+        "skip_button_only": "Show skip button",
+        "skip_automatically": "Automatically",
         "skip_sponsors": "Skip Sponsors",
         "skip_intro": "Skip Intermission/Intro Animation",
         "skip_outro": "Skip Endcards/Credits",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,6 +42,7 @@
         "skip_highlight": "Skip Highlight",
         "skip_filler_tangent": "Skip Filler Tangent",
         "show_markers": "Show Markers on Player",
+        "min_segment_length": "Minimum Segment Length (in seconds)",
         "theme": "Theme",
         "auto": "Auto",
         "dark": "Dark",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -43,6 +43,7 @@
         "skip_filler_tangent": "Skip Filler Tangent",
         "show_markers": "Show Markers on Player",
         "min_segment_length": "Minimum Segment Length (in seconds)",
+        "skip_segment": "Skip Segment",
         "theme": "Theme",
         "auto": "Auto",
         "dark": "Dark",

--- a/src/main.js
+++ b/src/main.js
@@ -162,6 +162,15 @@ const mixin = {
                 return Number(value);
             } else return defaultVal;
         },
+        getPreferenceJSON(key, defaultVal) {
+            var value;
+            if (
+                (value = new URLSearchParams(window.location.search).get(key)) !== null ||
+                (this.testLocalStorage && (value = localStorage.getItem(key)) !== null)
+            ) {
+                return JSON.parse(value);
+            } else return defaultVal;
+        },
         apiUrl() {
             return this.getPreferenceString("instance", "https://pipedapi.kavin.rocks");
         },


### PR DESCRIPTION
This overhauls the skipping logic and adds an option to show a skip button instead of autoskipping (configurable per category). The enter key also serves as a hotkey to skip. Fixes #894.

I've also added a simple option to prune segments shorter than a certain duration.

Known issues/possible future improvements:
- ~The skip button is ugly. Advice on making it look good would be appreciated, I'm not a web person.~
- ~The button location is suboptimal to be honest, it'd be nice to have a minimally intrusive overlay that doesn't get hidden.~
- It might be helpful to show the segment type on the skip button, but exisiting localization strings didn't look like they were flexible enough for that.
- An "unskip" action might be nice to have.