### PR TITLE
Fix skip button color when using light theme

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -771,6 +771,7 @@ export default {
     align-items: center;
     justify-content: center;
 
+    color: #fff;
     line-height: 1.5em;
 }
 


### PR DESCRIPTION
This is a hotfix following up on #2055. Turns out I forgot to test the light theme even though it's what I usually use. :P