### PR TITLE
Added ytify to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Contributions in any other form are also welcomed.
 -   [LibreTube](https://github.com/Libre-tube/LibreTube) - an alternative frontend for YouTube, for Android.
 -   [Hyperpipe](https://codeberg.org/Hyperpipe/Hyperpipe) - an alternative privacy respecting frontend for YouTube Music.
 -   [Musicale](https://github.com/Bellisario/musicale) - an alternative to YouTube Music, with style.
--   [ytify](https://github.com/n-ce/ytify) - a complementary minimal audio streaming frontEnd for YouTube.
+-   [ytify](https://github.com/n-ce/ytify) - a complementary minimal audio streaming frontend for YouTube.
 
 ## YourKit
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Contributions in any other form are also welcomed.
 -   [LibreTube](https://github.com/Libre-tube/LibreTube) - an alternative frontend for YouTube, for Android.
 -   [Hyperpipe](https://codeberg.org/Hyperpipe/Hyperpipe) - an alternative privacy respecting frontend for YouTube Music.
 -   [Musicale](https://github.com/Bellisario/musicale) - an alternative to YouTube Music, with style.
+-   [ytify](https://github.com/n-ce/ytify) - a complementary minimal audio streaming frontEnd for YouTube.
 
 ## YourKit
 


### PR DESCRIPTION
I am not sure if piped's policy is inline with the service ytify provides but It's been a few weeks it has been using the piped API and it has provided a very stable infrastructure support for the project so I think it may have a place here in this list.

I would understand if this PR is closed, still want to thank the Piped Team & community for maintaining such an awesome API.

**Repo** : https://github.com/n-ce/ytify/
**Deploy** : https://ytify.netlify.app