### PR TITLE
fix: make footer stick to the bottom

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,13 @@
 <template>
     <div class="flex flex-col w-full min-h-screen px-1vw py-5 reset" :class="[theme]">
-        <NavBar />
-
-        <main class="flex-1">
+        <div class="flex-1">
+            <NavBar />
             <router-view v-slot="{ Component }">
                 <keep-alive :max="5">
                     <component :is="Component" :key="$route.fullPath" />
                 </keep-alive>
             </router-view>
-        </main>
+        </div>
 
         <FooterComponent />
     </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,14 @@
 <template>
-    <div class="w-full min-h-screen px-1vw py-5 reset" :class="[theme]">
+    <div class="flex flex-col w-full min-h-screen px-1vw py-5 reset" :class="[theme]">
         <NavBar />
 
-        <router-view v-slot="{ Component }">
-            <keep-alive :max="5">
-                <component :is="Component" :key="$route.fullPath" />
-            </keep-alive>
-        </router-view>
+        <main class="flex-1">
+            <router-view v-slot="{ Component }">
+                <keep-alive :max="5">
+                    <component :is="Component" :key="$route.fullPath" />
+                </keep-alive>
+            </router-view>
+        </main>
 
         <FooterComponent />
     </div>


### PR DESCRIPTION
The current behavior is not visually appealing, and is more noticeable on pages with small amount of content like the register and login pages.