### PR TITLE
Fix: Add a hotkey to toggle Picture-In-Picture

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -100,7 +100,7 @@ export default {
         this.hotkeysPromise.then(() => {
             var self = this;
             this.$hotkeys(
-                "f,m,j,k,l,c,space,up,down,left,right,0,1,2,3,4,5,6,7,8,9,shift+n,shift+,,shift+.,return,.,,",
+                "f,m,j,k,l,c,space,up,down,left,right,0,1,2,3,4,5,6,7,8,9,shift+n,shift+,,shift+.,alt+p,return,.,,",
                 function (e, handler) {
                     const videoEl = self.$refs.videoEl;
                     switch (handler.key) {
@@ -195,6 +195,11 @@ export default {
                             break;
                         case "shift+.":
                             self.$player.trickPlay(Math.min(videoEl.playbackRate + 0.25, 2));
+                            break;
+                        case "alt+p":
+                            document.pictureInPictureElement
+                                ? document.exitPictureInPicture()
+                                : videoEl.requestPictureInPicture();
                             break;
                         case "return":
                             self.skipSegment(videoEl);


### PR DESCRIPTION
This PR closes issue #1056. It uses the Picture-in-Picture web API, which is not yet supported on some browsers. For a compatibility list of the Picture-in-Picture web API, please refer to the following link: [https://developer.mozilla.org/en-US/docs/Web/API/Document/pictureInPictureElement#browser_compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Document/pictureInPictureElement#browser_compatibility).