### PR TITLE
Minor improvement to channel description

### DIFF
--- a/src/components/ChannelPage.vue
+++ b/src/components/ChannelPage.vue
@@ -43,10 +43,12 @@
         </div>
 
         <!-- eslint-disable-next-line vue/no-v-html -->
-        <div class="whitespace-pre-wrap py-2 mx-1">
+        <div v-if="channel.description" class="whitespace-pre-wrap py-2 mx-1">
             <span v-if="fullDescription" v-html="purifyHTML(rewriteDescription(channel.description))" />
-            <span v-html="purifyHTML(rewriteDescription(channel.description.slice(0, 100))) + '...'" v-else />
+            <span v-html="purifyHTML(rewriteDescription(channel.description.slice(0, 100)))" v-else />
+            <span v-if="channel.description.length > 100 && !fullDescription">...</span>
             <button
+                v-if="channel.description.length > 100"
                 class="hover:underline font-semibold text-neutral-500 block whitespace-normal"
                 @click="fullDescription = !fullDescription"
             >


### PR DESCRIPTION
Related to #2204.

This PR fixes the actual behavior which occurs when a channel description has less than 100 characters and still shows the `Show more`/`Show less` buttons, even on channels with no description at all.
I also added a condition to render the description element only if there's one.