### PR TITLE
Replaced "delete-search" icon as (⨉) instead of (x)

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -25,7 +25,7 @@
                 @focus="onInputFocus"
                 @blur="onInputBlur"
             />
-            <span v-if="searchText" class="delete-search" @click="searchText = ''">x</span>
+            <span v-if="searchText" class="delete-search" @click="searchText = ''">⨉</span>
         </div>
         <!-- three vertical lines for toggling the hamburger menu on mobile -->
         <button class="md:hidden flex flex-col justify-end mr-3" @click="showTopNav = !showTopNav">
@@ -100,7 +100,7 @@
             @focus="onInputFocus"
             @blur="onInputBlur"
         />
-        <span v-if="searchText" class="delete-search" @click="searchText = ''">x</span>
+        <span v-if="searchText" class="delete-search" @click="searchText = ''">⨉</span>
     </div>
     <SearchSuggestions
         v-show="(searchText || showSearchHistory) && suggestionsVisible"


### PR DESCRIPTION
It looks so much better...

![Screenshot 2023-04-18 at 23-10-10 Piped](https://user-images.githubusercontent.com/33793273/232906327-e28a4bfd-82c5-480a-9853-2f215acf9392.png)
