### PR TITLE
Support editing playlist descriptions

### DIFF
--- a/src/components/PlaylistsPage.vue
+++ b/src/components/PlaylistsPage.vue
@@ -39,8 +39,26 @@
                     v-text="playlist.name"
                 />
             </router-link>
-            <button class="btn h-auto" @click="renamePlaylist(playlist.id)" v-t="'actions.rename_playlist'" />
+            <button class="btn h-auto" @click="showPlaylistEditModal(playlist)" v-t="'actions.edit_playlist'" />
             <button class="btn h-auto ml-2" @click="deletePlaylist(playlist.id)" v-t="'actions.delete_playlist'" />
+            <ModalComponent v-if="playlist.id == playlistToEdit" @close="playlistToEdit = null">
+                <div class="flex flex-col gap-2">
+                    <h2 v-t="'actions.edit_playlist'" />
+                    <input
+                        class="input"
+                        type="text"
+                        v-model="newPlaylistName"
+                        :placeholder="$t('actions.playlist_name')"
+                    />
+                    <input
+                        class="input"
+                        type="text"
+                        v-model="newPlaylistDescription"
+                        :placeholder="$t('actions.playlist_description')"
+                    />
+                    <button class="btn ml-auto" @click="editPlaylist(playlist)" v-t="'actions.okay'" />
+                </div>
+            </ModalComponent>
         </div>
     </div>
     <hr />
@@ -76,11 +94,16 @@
 </template>
 
 <script>
+import ModalComponent from "./ModalComponent.vue";
+
 export default {
     data() {
         return {
             playlists: [],
             bookmarks: [],
+            playlistToEdit: null,
+            newPlaylistName: "",
+            newPlaylistDescription: "",
         };
     },
     mounted() {
@@ -100,30 +123,48 @@ export default {
                 this.playlists = json;
             });
         },
-        renamePlaylist(id) {
-            const newName = prompt(this.$t("actions.new_playlist_name"));
-            if (!newName) return;
-            this.fetchJson(this.authApiUrl() + "/user/playlists/rename", null, {
-                method: "POST",
-                body: JSON.stringify({
-                    playlistId: id,
-                    newName: newName,
-                }),
-                headers: {
-                    Authorization: this.getAuthToken(),
-                    "Content-Type": "application/json",
-                },
-            }).then(json => {
-                if (json.error) alert(json.error);
-                else {
-                    this.playlists.forEach((playlist, index) => {
-                        if (playlist.id == id) {
-                            this.playlists[index].name = newName;
-                            return;
-                        }
-                    });
-                }
-            });
+        showPlaylistEditModal(playlist) {
+            this.newPlaylistName = playlist.name;
+            this.newPlaylistDescription = playlist.description;
+            this.playlistToEdit = playlist.id;
+        },
+        editPlaylist(selectedPlaylist) {
+            // save the new name and description since they could be overwritten during the http request
+            const newName = this.newPlaylistName;
+            const newDescription = this.newPlaylistDescription;
+            if (newName != selectedPlaylist.name) {
+                this.fetchJson(this.authApiUrl() + "/user/playlists/rename", null, {
+                    method: "POST",
+                    body: JSON.stringify({
+                        playlistId: selectedPlaylist.id,
+                        newName: newName,
+                    }),
+                    headers: {
+                        Authorization: this.getAuthToken(),
+                        "Content-Type": "application/json",
+                    },
+                }).then(json => {
+                    if (json.error) alert(json.error);
+                    else selectedPlaylist.name = newName;
+                });
+            }
+            if (newDescription != selectedPlaylist.description) {
+                this.fetchJson(this.authApiUrl() + "/user/playlists/description", null, {
+                    method: "PATCH",
+                    body: JSON.stringify({
+                        playlistId: selectedPlaylist.id,
+                        description: newDescription,
+                    }),
+                    headers: {
+                        Authorization: this.getAuthToken(),
+                        "Content-Type": "application/json",
+                    },
+                }).then(json => {
+                    if (json.error) alert(json.error);
+                    else selectedPlaylist.description = newDescription;
+                });
+            }
+            this.playlistToEdit = null;
         },
         deletePlaylist(id) {
             if (confirm(this.$t("actions.delete_playlist_confirm")))
@@ -262,5 +303,6 @@ export default {
             this.bookmarks.splice(index, 1);
         },
     },
+    components: { ModalComponent },
 };
 </script>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -107,7 +107,6 @@
         "follow_link": "اتبع الرابط",
         "copy_link": "نسخ الرابط",
         "time_code": "رمز الوقت (بالثواني)",
-        "rename_playlist": "إعادة تسمية قائمة التشغيل",
         "new_playlist_name": "اسم قائمة تشغيل جديد",
         "show_chapters": "الفصول",
         "store_search_history": "حفظ سجل البحث",

--- a/src/locales/az.json
+++ b/src/locales/az.json
@@ -100,7 +100,6 @@
         "instance_auth_selection": "Təsdiqləmə Nümunəsi Seçimi",
         "clone_playlist": "Oynatma Siyahısın Klonla",
         "clone_playlist_success": "Uğurla klonlandı!",
-        "rename_playlist": "Oynatma siyahısın yenidən adlandır",
         "time_code": "Vaxt kodu (saniyələrlə)",
         "store_search_history": "Axtarış tarixçəsini saxla",
         "documentation": "Sənədləşdirmə",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -99,7 +99,6 @@
         "clone_playlist": "Клониране на плейлист",
         "clone_playlist_success": "Успешно клониране!",
         "backup_preferences": "Архивиране на настройките",
-        "rename_playlist": "Преименуване на плейлиста",
         "new_playlist_name": "Ново име на плейлиста",
         "back_to_home": "Обратно към начална страница",
         "status_page": "Статус",

--- a/src/locales/bs.json
+++ b/src/locales/bs.json
@@ -77,7 +77,6 @@
         "minimize_chapters_default": "Smanjite poglavlja po zadanom",
         "show_watch_on_youtube": "Prikaži „Gledaj na YouTube-u” dugme",
         "different_auth_instance": "Koristite drugu instancu za autentifikaciju",
-        "rename_playlist": "Preimenuj listu izvođenja",
         "new_playlist_name": "Novi naziv liste izvođenja",
         "with_timecode": "Podijelite s vremenskim kodom",
         "piped_link": "Piped poveznica",

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -103,7 +103,6 @@
         "time_code": "Moment (en segons)",
         "copy_link": "Copiar l'enllaç",
         "follow_link": "Vés a l'enllaç",
-        "rename_playlist": "Canviar el nom de la llista de reproducció",
         "new_playlist_name": "Nom nou de la llista de reproducció",
         "store_search_history": "Emmagatzema l'historial de cerca",
         "instance_donations": "Donacions a instàncies",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -104,7 +104,6 @@
         "follow_link": "Otevřít odkaz",
         "copy_link": "Kopírovat odkaz",
         "time_code": "Časový kód (v sekundách)",
-        "rename_playlist": "Přejmenovat playlist",
         "new_playlist_name": "Nový název playlistu",
         "show_chapters": "Kapitoly",
         "store_search_history": "Ukládat historii vyhledávání",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -75,7 +75,6 @@
         "instance_auth_selection": "Auswahl der Autentifizierungsinstanz",
         "clone_playlist": "Playlist duplizieren",
         "clone_playlist_success": "Erfolgreich dupliziert!",
-        "rename_playlist": "Playlist umbenennen",
         "new_playlist_name": "Neuer Name der Playlist",
         "piped_link": "Piped-Link",
         "download_as_txt": "Als .txt herunterladen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -111,7 +111,9 @@
         "backup_preferences": "Backup preferences",
         "restore_preferences": "Restore preferences",
         "back_to_home": "Back to home",
-        "rename_playlist": "Rename playlist",
+        "edit_playlist": "Edit playlist",
+        "playlist_name": "Playlist name",
+        "playlist_description": "Playlist description",
         "new_playlist_name": "New playlist name",
         "share": "Share",
         "with_timecode": "Share with time code",
@@ -135,7 +137,8 @@
         "show_more": "Show more",
         "show_less": "Show less",
         "create_group": "Create group",
-        "group_name": "Group name"
+        "group_name": "Group name",
+        "okay": "Okay"
     },
     "comment": {
         "pinned_by": "Pinned by {author}",

--- a/src/locales/eo.json
+++ b/src/locales/eo.json
@@ -55,7 +55,6 @@
         "hide_replies": "Kaŝi Respondojn",
         "add_to_playlist": "Aldoni al ludlisto",
         "delete_playlist": "Forigi Ludliston",
-        "rename_playlist": "Renomi ludliston",
         "download_as_txt": "Elŝuti kiel .txt",
         "piped_link": "Piped-ligilo",
         "copy_link": "Kopii ligilon",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -103,7 +103,6 @@
         "invalidate_session": "Cerrar sesión en todos los dispositivos",
         "instance_auth_selection": "Selección de la Instancia de Autentificación",
         "download_as_txt": "Descargar como .txt",
-        "rename_playlist": "Cambiar el nombre de la lista de reproducción",
         "new_playlist_name": "Nuevo nombre de la lista de reproducción",
         "share": "Compartir",
         "with_timecode": "Compartir con código de tiempo",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -101,7 +101,6 @@
         "show_watch_on_youtube": "Näytä Katso YouTubessa -painike",
         "different_auth_instance": "Käytä eri instanssia todennukseen",
         "download_as_txt": "Lataa .txt-tiedostona",
-        "rename_playlist": "Nimeä soittolista uudelleen",
         "show_chapters": "Luvut",
         "minimize_comments": "Minimoi kommentit",
         "minimize_comments_default": "Minimoi kommentit oletusarvoisesti",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -103,7 +103,6 @@
         "piped_link": "Lien vers Piped",
         "follow_link": "Ouvrir le lien",
         "time_code": "Horodatage (en secondes)",
-        "rename_playlist": "Renommer la liste de lecture",
         "new_playlist_name": "Nouveau nom de la liste de lecture",
         "show_chapters": "Chapitres",
         "store_search_history": "Mémoriser l'historique de recherche",

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -104,7 +104,6 @@
         "search": "חיפוש (Ctrl+K)",
         "loop_this_video": "ניגון הסרטון בלולאה",
         "minimize_recommendations": "מזעור המלצות",
-        "rename_playlist": "שינוי שם רשימת נגינה",
         "new_playlist_name": "שם לרשימת נגינה חדשה",
         "show_chapters": "פרקים",
         "skip_intro": "דילוג על הפוגה/הנפשת הקדמה",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -113,7 +113,6 @@
         "confirm_reset_preferences": "Stvarno želiš resetirati tvoje postavke?",
         "backup_preferences": "Spremi sigurnosnu kopiju postavki",
         "with_timecode": "Dijeli s vremenskim kodom",
-        "rename_playlist": "Preimenuj popis snimaka",
         "new_playlist_name": "Ime novog popisa snimaka",
         "share": "Dijeli",
         "show_chapters": "Poglavlja",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -92,7 +92,6 @@
         "clone_playlist_success": "Sikeresen klónozva!",
         "reset_preferences": "Alaphelyzetbe állítás",
         "restore_preferences": "Beállítások betöltése fájlból",
-        "rename_playlist": "Átnevez",
         "instance_donations": "Szerver adományozások",
         "piped_link": "Piped link",
         "time_code": "Idő kód (másodpercekben)",

--- a/src/locales/hy.json
+++ b/src/locales/hy.json
@@ -76,7 +76,6 @@
         "confirm_reset_preferences": "Իսկապե՞ս ուզում եք վերակայել ձեր նախապատվությունները:",
         "backup_preferences": "Պահուստային նախապատվություններ",
         "restore_preferences": "Վերականգնել նախապատվությունները",
-        "rename_playlist": "Վերանվանել տեսացանկը",
         "new_playlist_name": "Տեսացանկի նոր անվանում",
         "follow_link": "Հետևել հղմանը",
         "instance_donations": "Օրինակների նվիրատվություններ",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -100,7 +100,6 @@
         "restore_preferences": "Pulihkan preferensi",
         "confirm_reset_preferences": "Apakah Anda yakin ingin mengatur ulang preferensi Anda?",
         "backup_preferences": "Cadangkan preferensi",
-        "rename_playlist": "Ubah nama daftar putar",
         "new_playlist_name": "Nama daftar putar baru",
         "share": "Bagikan",
         "with_timecode": "Bagikan dengan kode waktu",

--- a/src/locales/is.json
+++ b/src/locales/is.json
@@ -96,7 +96,6 @@
         "instance_donations": "Framlög til netþjóns",
         "status_page": "Staða",
         "source_code": "Frumkóði",
-        "rename_playlist": "Endurnefna spilunarlista",
         "new_playlist_name": "Nýtt heiti spilunarlista",
         "share": "Deila",
         "with_timecode": "Deilа með tímakóða",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -88,7 +88,6 @@
         "follow_link": "Apri il collegamento",
         "with_timecode": "Condividi con marca temporale",
         "new_playlist_name": "Nuovo nome dalla playlist",
-        "rename_playlist": "Rinomina la playlist",
         "show_chapters": "Capitoli",
         "store_search_history": "Memorizza la cronologia delle ricerche",
         "status_page": "Stato",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -114,7 +114,6 @@
         "documentation": "ドキュメント",
         "reset_preferences": "設定を初期化",
         "confirm_reset_preferences": "設定をリセットしますか？",
-        "rename_playlist": "再生リスト名を変更",
         "piped_link": "Pipedリンク",
         "new_playlist_name": "新しい再生リスト名",
         "follow_link": "リンクを開く",

--- a/src/locales/kab.json
+++ b/src/locales/kab.json
@@ -98,7 +98,6 @@
         "backup_preferences": "Ḥrez ismenyifen",
         "restore_preferences": "Err-d ismenyifen",
         "back_to_home": "Uɣal ɣer ugejdan",
-        "rename_playlist": "Beddel isem i tebdart n tɣuri",
         "follow_link": "Ḍfer aseɣwen",
         "show_chapters": "Ixfawen",
         "show_watch_on_youtube": "Sken taqeffalt Wali ɣef YouTube",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -70,7 +70,6 @@
         "show_chapters": "챕터",
         "download_as_txt": ".txt로 다운로드",
         "new_playlist_name": "새 재생목록 이름",
-        "rename_playlist": "재생목록 이름 변경",
         "share": "공유",
         "copy_link": "링크 복사",
         "time_code": "시작 시간 (초)",

--- a/src/locales/lt.json
+++ b/src/locales/lt.json
@@ -80,7 +80,6 @@
         "reply_count": "{count} atsakymai",
         "show_chapters": "Skirsniai",
         "piped_link": "Piped nuoroda",
-        "rename_playlist": "Pervardyti grojaraštį",
         "follow_link": "Sekti nuorodą",
         "store_search_history": "Išsaugoti paieškos istoriją",
         "hide_watched": "Slėpti žiūrėtus vaizdo įrašus sklaidos kanale",

--- a/src/locales/nb_NO.json
+++ b/src/locales/nb_NO.json
@@ -81,7 +81,6 @@
         "confirm_reset_preferences": "Tilbakestill alle innstillingene?",
         "restore_preferences": "Gjenopprett innstillinger",
         "show_chapters": "Kapitler",
-        "rename_playlist": "Gi spillelisten ny navn",
         "new_playlist_name": "Nytt spillelistenavn",
         "share": "Del",
         "with_timecode": "Del med tidskode",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -80,7 +80,6 @@
         "instance_auth_selection": "Selectie authenticatie-instantie",
         "clone_playlist": "Afspeellijst dupliceren",
         "download_as_txt": "Downloaden als .txt",
-        "rename_playlist": "Afspeellijst hernoemen",
         "new_playlist_name": "Nieuwe afspeellijstnaam",
         "share": "Delen",
         "documentation": "Documentatie",

--- a/src/locales/oc.json
+++ b/src/locales/oc.json
@@ -98,7 +98,6 @@
         "invalidate_session": "Se desconnectar de totes los aparelhs",
         "different_auth_instance": "Utilizar una instància diferenta per l’autentificacion",
         "back_to_home": "Tornar a l’acuèlh",
-        "rename_playlist": "Renomenar la lista de lectura",
         "new_playlist_name": "Nom novèl de la lista de lectura",
         "with_timecode": "Partejar amb còdi orari",
         "piped_link": "Ligam cap a Piped",

--- a/src/locales/or.json
+++ b/src/locales/or.json
@@ -35,7 +35,6 @@
         "show_recommendations": "ସୁପାରିଶଗୁଡିକ ଦେଖାନ୍ତୁ",
         "disable_lbry": "ଷ୍ଟ୍ରିମିଂ ପାଇଁ LBRY ଅକ୍ଷମ କରନ୍ତୁ",
         "search": "ସନ୍ଧାନ କରନ୍ତୁ (Ctrl+K)",
-        "rename_playlist": "ପ୍ଲେ ଲିଷ୍ଟର ନାମ ପରିବର୍ତ୍ତନ କରନ୍ତୁ",
         "new_playlist_name": "ନୂତନ ପ୍ଲେଲିଷ୍ଟ ନାମ",
         "channel_name_asc": "ସ୍ରୋତ ର ନାମ (A-Z)",
         "least_recent": "ସର୍ବନିମ୍ନ ସାମ୍ପ୍ରତିକ",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -102,7 +102,6 @@
         "source_code": "Kod źródłowy",
         "show_chapters": "Rozdziały",
         "minimize_chapters_default": "Ukryj rozdziały",
-        "rename_playlist": "Zmień nazwę playlisty",
         "follow_link": "Otwórz link",
         "minimize_comments_default": "Ukryj sekcję komentarzy",
         "minimize_comments": "Ukryj komentarze",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -110,7 +110,6 @@
         "new_playlist_name": "Novo nome da lista de reprodução",
         "minimize_comments": "Minimizar Comentários",
         "back_to_home": "Voltar ao início",
-        "rename_playlist": "Renomear",
         "copy_link": "Copiar ligação",
         "time_code": "Código de tempo (em segundos)",
         "minimize_comments_default": "Minimizar Comentários por defeito",

--- a/src/locales/pt_BR.json
+++ b/src/locales/pt_BR.json
@@ -87,7 +87,6 @@
         "restore_preferences": "Restaurar preferências",
         "back_to_home": "Voltar ao início",
         "share": "Compartilhar",
-        "rename_playlist": "Renomear playlist",
         "new_playlist_name": "Novo nome da playlist",
         "with_timecode": "Compartilhar com código de tempo",
         "piped_link": "Link do Piped",

--- a/src/locales/pt_PT.json
+++ b/src/locales/pt_PT.json
@@ -93,7 +93,6 @@
         "invalidate_session": "Terminar sessão em todos os aparelhos",
         "clone_playlist": "Clonar Lista de Reprodução",
         "clone_playlist_success": "Clonada com sucesso!",
-        "rename_playlist": "Renomear",
         "restore_preferences": "Restaurar configurações",
         "confirm_reset_preferences": "Tem a certeza que quer redefinir as suas configurações?",
         "new_playlist_name": "Novo nome da lista de reprodução",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -59,7 +59,6 @@
         "clone_playlist_success": "Clonată cu succes!",
         "reset_preferences": "Resetați preferințele",
         "confirm_reset_preferences": "Sunteți sigur că doriți să vă resetați preferințele?",
-        "rename_playlist": "Redenumiți playlist-ul",
         "new_playlist_name": "Numele playlist-ului nou",
         "share": "Distribuiți",
         "follow_link": "Urmați link-ul",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -97,7 +97,6 @@
         "clone_playlist": "Клонировать плейлист",
         "clone_playlist_success": "Успешно клонировано!",
         "show_chapters": "Главы",
-        "rename_playlist": "Переименовать плейлист",
         "new_playlist_name": "Новое название плейлиста",
         "share": "Поделиться",
         "with_timecode": "Поделиться с таймкодом",

--- a/src/locales/si.json
+++ b/src/locales/si.json
@@ -81,7 +81,6 @@
         "backup_preferences": "සැකසුම් උපස්ථ කරන්න",
         "restore_preferences": "සැකසුම් නැවත පිහිටුවන්න",
         "back_to_home": "ආපසු මුල් පිටුවට",
-        "rename_playlist": "වාදන ලැයිස්තුව නැවත නම් කරන්න",
         "share": "බෙදාගන්න",
         "with_timecode": "කාල කේතය සමඟ බෙදා ගන්න",
         "piped_link": "පයිප්ඩ් සබැඳිය",

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -72,7 +72,6 @@
         "view_ssl_score": "Zobraziť SSL skóre",
         "filter": "Filter",
         "delete_playlist_video_confirm": "Odstrániť video zo zoznamu?",
-        "rename_playlist": "Premenovať zoznam skladieb",
         "new_playlist_name": "Nový názov zoznamu skladieb",
         "share": "Zdieľať",
         "follow_link": "Nasledujte odkaz",

--- a/src/locales/sr.json
+++ b/src/locales/sr.json
@@ -100,7 +100,6 @@
         "status_page": "Статус",
         "instance_donations": "Донације инстанци",
         "show_chapters": "Поглавља",
-        "rename_playlist": "Преименуј плејлисту",
         "with_timecode": "Подели са временским кодом",
         "piped_link": "Piped веза",
         "back_to_home": "Врати се на почетну",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -87,7 +87,6 @@
         "with_timecode": "Zaman Koduyla Paylaş",
         "piped_link": "Piped Bağlantısı",
         "share": "Paylaş",
-        "rename_playlist": "Oynatma Listesini Yeniden Adlandır",
         "new_playlist_name": "Yeni Oynatma Listesi Adı",
         "show_chapters": "Bölümler",
         "store_search_history": "Arama Geçmişini Sakla",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -79,7 +79,6 @@
         "logout": "Вийти з цього пристрою",
         "backup_preferences": "Налаштування резервного копіювання",
         "download_as_txt": "Завантажити як .txt",
-        "rename_playlist": "Перейменувати список відтворення",
         "show_chapters": "Розділи",
         "invalidate_session": "Вийти з усіх пристроїв",
         "clone_playlist": "Клонувати список відтворення",

--- a/src/locales/zh_Hans.json
+++ b/src/locales/zh_Hans.json
@@ -87,7 +87,6 @@
         "share": "分享",
         "with_timecode": "用时间码分享",
         "time_code": "时间码（单位：秒）",
-        "rename_playlist": "重命名播放列表",
         "new_playlist_name": "新播放列表名",
         "show_chapters": "章节",
         "store_search_history": "保存搜索历史",

--- a/src/locales/zh_Hant.json
+++ b/src/locales/zh_Hant.json
@@ -64,7 +64,6 @@
         "download_as_txt": "以 .txt 下載",
         "share": "分享",
         "new_playlist_name": "播放清單的新名稱",
-        "rename_playlist": "重新命名播放清單",
         "reset_preferences": "重設偏好設定",
         "confirm_reset_preferences": "確定要重設偏好設定嗎？",
         "backup_preferences": "備份偏好設定",


### PR DESCRIPTION
closes #2447
The approach chosen is to replace the "Rename playlist" button and dialog with an "Edit playlist" button that allows to modify both, the description and the name of the playlist.

(haven't been able to test this yet, likely the backend of kavin.rocks is not yet on the latest version?)