### PR TITLE
Apply rounded border to channels in search results

### DIFF
--- a/src/components/ChannelItem.vue
+++ b/src/components/ChannelItem.vue
@@ -1,7 +1,7 @@
 <template>
-    <div>
+    <div class="flex flex-col flex-justify-between">
         <router-link :to="props.item.url">
-            <div class="flex justify-center h-30">
+            <div class="flex justify-center h-10-rem mb-4">
                 <img class="aspect-square rounded-full" :src="props.item.thumbnail" loading="lazy" />
             </div>
             <p>

--- a/src/components/ChannelItem.vue
+++ b/src/components/ChannelItem.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="flex flex-col flex-justify-between">
         <router-link :to="props.item.url">
-            <div class="flex justify-center h-10-rem mb-4">
+            <div class="flex justify-center h-[10rem] mb-4">
                 <img class="aspect-square rounded-full" :src="props.item.thumbnail" loading="lazy" />
             </div>
             <p>

--- a/src/components/ChannelItem.vue
+++ b/src/components/ChannelItem.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
         <router-link :to="props.item.url">
-            <div class="relative">
-                <img class="w-full aspect-square rounded-full" :src="props.item.thumbnail" loading="lazy" />
+            <div class="flex justify-center h-30">
+                <img class="aspect-square rounded-full" :src="props.item.thumbnail" loading="lazy" />
             </div>
             <p>
                 <span v-text="props.item.name" />

--- a/src/components/ChannelItem.vue
+++ b/src/components/ChannelItem.vue
@@ -2,7 +2,7 @@
     <div>
         <router-link :to="props.item.url">
             <div class="relative">
-                <img class="w-full aspect-square" :src="props.item.thumbnail" loading="lazy" />
+                <img class="w-full aspect-square channel-container" :src="props.item.thumbnail" loading="lazy" />
             </div>
             <p>
                 <span v-text="props.item.name" />
@@ -32,3 +32,9 @@ const props = defineProps({
     item: Object,
 });
 </script>
+
+<style>
+.channel-container {
+    border-radius: 100%;
+}
+</style>

--- a/src/components/ChannelItem.vue
+++ b/src/components/ChannelItem.vue
@@ -2,7 +2,7 @@
     <div>
         <router-link :to="props.item.url">
             <div class="relative">
-                <img class="w-full aspect-square channel-container" :src="props.item.thumbnail" loading="lazy" />
+                <img class="w-full aspect-square rounded-full" :src="props.item.thumbnail" loading="lazy" />
             </div>
             <p>
                 <span v-text="props.item.name" />
@@ -32,9 +32,3 @@ const props = defineProps({
     item: Object,
 });
 </script>
-
-<style>
-.channel-container {
-    border-radius: 100%;
-}
-</style>

--- a/src/components/PlaylistItem.vue
+++ b/src/components/PlaylistItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="flex flex-col flex-justify-between">
         <router-link :to="props.item.url">
             <div class="relative">
                 <img class="w-full" :src="props.item.thumbnail" loading="lazy" />

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="showVideo">
+    <div class="flex flex-col flex-justify-between" v-if="showVideo">
         <router-link
             class="focus:underline hover:underline inline-block w-full"
             :to="{

--- a/uno.config.js
+++ b/uno.config.js
@@ -8,15 +8,6 @@ import presetWebFonts from "@unocss/preset-web-fonts";
 
 export default defineConfig({
     transformers: [transformerDirective(), transformerVariantGroup()],
-    rules: [
-        [
-            /^h-([\d]+)-rem$/,
-            ([_, num]) => {
-                _; // fixes linting error
-                return { height: `${num}rem` };
-            },
-        ],
-    ],
     presets: [
         presetUno({
             dark: "media",

--- a/uno.config.js
+++ b/uno.config.js
@@ -8,7 +8,15 @@ import presetWebFonts from "@unocss/preset-web-fonts";
 
 export default defineConfig({
     transformers: [transformerDirective(), transformerVariantGroup()],
-    rules: [[/^h-([\.\d]+)-rem$/, ([_, num]) => ({ height: `${num}rem` })]],
+    rules: [
+        [
+            /^h-([\d]+)-rem$/,
+            ([_, num]) => {
+                _; // fixes linting error
+                return { height: `${num}rem` };
+            },
+        ],
+    ],
     presets: [
         presetUno({
             dark: "media",

--- a/uno.config.js
+++ b/uno.config.js
@@ -8,6 +8,7 @@ import presetWebFonts from "@unocss/preset-web-fonts";
 
 export default defineConfig({
     transformers: [transformerDirective(), transformerVariantGroup()],
+    rules: [[/^h-([\.\d]+)-rem$/, ([_, num]) => ({ height: `${num}rem` })]],
     presets: [
         presetUno({
             dark: "media",


### PR DESCRIPTION
Built per request in linked issue
Closes #2281 

At the least it provides a way to easily distinguish channels from videos in search results outside of height differences
