### PR TITLE
fix: size of channel avatar in search results on large screens

### DIFF
--- a/src/components/ChannelItem.vue
+++ b/src/components/ChannelItem.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="flex flex-col flex-justify-between">
         <router-link :to="props.item.url">
-            <div class="flex justify-center h-[10rem] mb-4">
-                <img class="aspect-square rounded-full" :src="props.item.thumbnail" loading="lazy" />
+            <div class="flex justify-center my-4">
+                <img class="aspect-square rounded-full w-[50%]" :src="props.item.thumbnail" loading="lazy" />
             </div>
             <p>
                 <span v-text="props.item.name" />


### PR DESCRIPTION
#2672 caused channel avatars to be very small in comparison to thumbnails using a large screen device.
By using a dynamic width of 50%, the channel avatar aligns properly with video thumbnails, no matter the screen size.