### PR TITLE
Adding padding to center search icon in navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -218,7 +218,7 @@ b {
 }
 
 .input {
-    @apply pl-2.5;
+    @apply px-2.5;
 }
 
 .input:focus {


### PR DESCRIPTION
The search icon was not aligned in the center so I added even alignment on the x-axis. It will nicely align all inputs since the change on the input class.