### PR TITLE
Allow set subtitle language from url parameter

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -594,6 +594,14 @@ export default {
 
                     const autoDisplayCaptions = this.getPreferenceBoolean("autoDisplayCaptions", false);
                     this.$player.setTextTrackVisibility(autoDisplayCaptions);
+
+                    const prefSubtitles = this.getPreferenceString("subtitles", null);
+                    const textTracks = this.$player.getTextTracks();
+                    const subtitleIdx = textTracks.findIndex(textTrack => textTrack.language == prefSubtitles);
+                    if (subtitleIdx >= 0) {
+                        this.$player.setTextTrackVisibility(true);
+                        this.$player.selectTextTrack(textTracks[subtitleIdx]);
+                    }
                 })
                 .catch(e => {
                     console.error(e);

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -595,13 +595,17 @@ export default {
                     const autoDisplayCaptions = this.getPreferenceBoolean("autoDisplayCaptions", false);
                     this.$player.setTextTrackVisibility(autoDisplayCaptions);
 
-                    const prefSubtitles = this.getPreferenceString("subtitles", null);
-                    const textTracks = this.$player.getTextTracks();
-                    const subtitleIdx = textTracks.findIndex(textTrack => textTrack.language == prefSubtitles);
-                    if (subtitleIdx >= 0) {
+                    (() => {
+                        const prefSubtitles = this.getPreferenceString("subtitles", "");
+                        if (prefSubtitles === "") return;
+
+                        const textTracks = this.$player.getTextTracks();
+                        const subtitleIdx = textTracks.findIndex(textTrack => textTrack.language == prefSubtitles);
+                        if (subtitleIdx == -1) return;
+
                         this.$player.setTextTrackVisibility(true);
                         this.$player.selectTextTrack(textTracks[subtitleIdx]);
-                    }
+                    })();
                 })
                 .catch(e => {
                     console.error(e);

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -595,17 +595,15 @@ export default {
                     const autoDisplayCaptions = this.getPreferenceBoolean("autoDisplayCaptions", false);
                     this.$player.setTextTrackVisibility(autoDisplayCaptions);
 
-                    (() => {
-                        const prefSubtitles = this.getPreferenceString("subtitles", "");
-                        if (prefSubtitles === "") return;
-
+                    const prefSubtitles = this.getPreferenceString("subtitles", "");
+                    if (prefSubtitles !== "") {
                         const textTracks = this.$player.getTextTracks();
                         const subtitleIdx = textTracks.findIndex(textTrack => textTrack.language == prefSubtitles);
-                        if (subtitleIdx == -1) return;
-
-                        this.$player.setTextTrackVisibility(true);
-                        this.$player.selectTextTrack(textTracks[subtitleIdx]);
-                    })();
+                        if (subtitleIdx != -1) {
+                            this.$player.setTextTrackVisibility(true);
+                            this.$player.selectTextTrack(textTracks[subtitleIdx]);
+                        }
+                    }
                 })
                 .catch(e => {
                     console.error(e);


### PR DESCRIPTION
**As** user,
**I want to** set subtitles language from url parameters, 
**So i** do not need to set subtitle language each time i switch instances

you can set `subtitles=xx` (example: `subtitles=en`) on url parameter to set video subtitle language. full url example: https://piped.video/watch?v=6stlCkUDG_s&subtitles=en

i choose query `subtitles` so it's compatible with [invidious url parameter](https://docs.invidious.io/url-parameters/)

this is especially useful when you have addons like redirector

improvement over https://github.com/TeamPiped/Piped/issues/2669 and https://github.com/TeamPiped/Piped/issues/223