### PR TITLE
Don't show audio language option if language is undetermined

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -537,10 +537,8 @@ export default {
                         player.selectAudioLanguage(lang);
                     }
 
-                    (() => {
-                        const audioLanguages = player.getAudioLanguages();
-                        if (audioLanguages.length == 1 && audioLanguages[0] == "und") return;
-
+                    const audioLanguages = player.getAudioLanguages();
+                    if (audioLanguages.length > 1) {
                         const overflowMenuButtons = this.$ui.getConfiguration().overflowMenuButtons;
                         // append language menu on index 1
                         const newOverflowMenuButtons = [
@@ -549,7 +547,7 @@ export default {
                             ...overflowMenuButtons.slice(1),
                         ];
                         this.$ui.configure("overflowMenuButtons", newOverflowMenuButtons);
-                    })();
+                    }
 
                     if (qualityConds) {
                         var leastDiff = Number.MAX_VALUE;

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -472,14 +472,7 @@ export default {
 
                 this.$ui = new shaka.ui.Overlay(localPlayer, this.$refs.container, videoEl);
 
-                const overflowMenuButtons = [
-                    "quality",
-                    "language",
-                    "captions",
-                    "picture_in_picture",
-                    "playback_rate",
-                    "airplay",
-                ];
+                const overflowMenuButtons = ["quality", "captions", "picture_in_picture", "playback_rate", "airplay"];
 
                 if (this.isEmbed) {
                     overflowMenuButtons.push("open_new_tab");
@@ -543,6 +536,20 @@ export default {
                         }
                         player.selectAudioLanguage(lang);
                     }
+
+                    (() => {
+                        const audioLanguages = player.getAudioLanguages();
+                        if (audioLanguages.length == 1 && audioLanguages[0] == "und") return;
+
+                        const overflowMenuButtons = this.$ui.getConfiguration().overflowMenuButtons;
+                        // append language menu on index 1
+                        const newOverflowMenuButtons = [
+                            ...overflowMenuButtons.slice(0, 1),
+                            "language",
+                            ...overflowMenuButtons.slice(1),
+                        ];
+                        this.$ui.configure("overflowMenuButtons", newOverflowMenuButtons);
+                    })();
 
                     if (qualityConds) {
                         var leastDiff = Number.MAX_VALUE;


### PR DESCRIPTION
as a viewer
i want simple option
so i
  - don't need to see unnecessary option
  - have more simple option 

by not showing audio language option if language is undetermined

fix https://github.com/TeamPiped/Piped/issues/1761