### PR TITLE
Use instance name when downloading playlist as .txt

### DIFF
--- a/src/components/PlaylistPage.vue
+++ b/src/components/PlaylistPage.vue
@@ -158,7 +158,7 @@ export default {
         downloadPlaylistAsTxt() {
             var data = "";
             this.playlist.relatedStreams.forEach(element => {
-                data += "https://piped.video" + element.url + "\n";
+                data += window.location.origin + element.url + "\n";
             });
             this.download(data, this.playlist.name + ".txt", "text/plain");
         },


### PR DESCRIPTION
Right now, when you download a playlist .txt file, it uses "piped.video". This PR makes it use the current instance name.