### PR TITLE
Set fixed uploader avatar size on Watch Video page

### DIFF
--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -72,7 +72,14 @@
             <div class="flex flex-wrap gap-1">
                 <!-- Channel Image & Info -->
                 <div class="flex items-center">
-                    <img :src="video.uploaderAvatar" alt="" loading="lazy" class="rounded-full" />
+                    <img
+                        height="48"
+                        width="48"
+                        :src="video.uploaderAvatar"
+                        alt=""
+                        loading="lazy"
+                        class="rounded-full"
+                    />
                     <router-link v-if="video.uploaderUrl" class="link ml-1.5" :to="video.uploaderUrl">{{
                         video.uploader
                     }}</router-link>


### PR DESCRIPTION
In new backend version the avatar sizes became too big. Fix it by setting the fixed image size.