### PR TITLE
fix: really minimize the video description by default

### DIFF
--- a/src/components/WatchVideo.vue
+++ b/src/components/WatchVideo.vue
@@ -416,7 +416,7 @@ export default {
         this.active = true;
         this.selectedAutoPlay = this.getPreferenceBoolean("autoplay", false);
         this.showComments = !this.getPreferenceBoolean("minimizeComments", false);
-        this.showDesc = !this.getPreferenceBoolean("minimizeDescription", false);
+        this.showDesc = !this.getPreferenceBoolean("minimizeDescription", true);
         this.showRecs = !this.getPreferenceBoolean("minimizeRecommendations", false);
         this.showChapters = !this.getPreferenceBoolean("minimizeChapters", false);
         if (this.video?.duration) {


### PR DESCRIPTION
bugfix for PR https://github.com/TeamPiped/Piped/commit/24ffe2ef93c528da8e2dff768b55521345d36785

Apologize, I didn't test it beforehand. On my local clone, the description is now minimized by default in all modern browsers (chromium, firefox).

Please review and apply the fix if it's also working for you now.