### PR TITLE
add vidyodl to list of Made with Piped in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Contributions in any other form are also welcomed.
 -   [YTDLnis](https://github.com/deniscerri/ytdlnis) - Video and audio downloader for Android that uses Piped to update formats.
 -   [DeskVideo](https://github.com/malisipi/DeskVideo) - A desktop styled, customizable alternative front-end for YouTube.
 -   [Harmony Music](https://github.com/anandnet/Harmony-Music) - YouTube Music alternative for Android, built with Flutter that supports piped linking for playlists.
+-   [vidyodl](https://github.com/MrKovar/vidyodl) - A simple API to download videos from YouTube, using Piped.
 
 ## YourKit
 


### PR DESCRIPTION
I recently finished up a project intended for use on my home server that I figured this group of devs may find either useful or want to use themselves. It uses the list of proxies from piped-proxy repo to find whichever proxy is up and then determines the fastest one for a quick video downloading process using ffmpeg. 