### PR TITLE
Dockerfile: rm EXPOSE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm \
 FROM nginx:alpine
 
 COPY --from=build /app/dist/ /usr/share/nginx/html/
+
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
 COPY docker/entrypoint.sh /entrypoint.sh
 
-EXPOSE 80
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
The EXPOSE is inferred from the base image which in this case is nginx

So, we need not expicitly define it. One less layer in final image :)