### PR TITLE
chore(readme): fix typos and 'made with piped' cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ By using Piped, you can freely watch and listen to content without the fear of p
 -   [x] Playing just audio
 -   [x] PWA support
 -   [x] Locally saved Preferences
--   [x] [Available eamPiped/Pipedin many languages](src/locales), thanks to [our translators](https://hosted.weblate.org/projects/piped/frontend/)
+-   [x] [Available in many languages](src/locales), thanks to [our translators](https://hosted.weblate.org/projects/piped/frontend/)
 -   [x] Embedded video support
 -   [x] No age restriction
 -   [x] Bypasses Geo restrictions if possible through a federated network
@@ -147,19 +147,20 @@ Contributions in any other form are also welcomed.
 **Mobile/desktop apps**
 -   [LibreTube](https://github.com/Libre-tube/LibreTube) - an alternative frontend for YouTube, for Android.
 -   [YTDLnis](https://github.com/deniscerri/ytdlnis) - Video and audio downloader for Android that uses Piped to update formats.
--   [Yattee](https://github.com/yattee/yattee) - an alternative frontend for YouTube, for MacOS IOS.
+-   [Yattee](https://github.com/yattee/yattee) - an alternative frontend for YouTube, for MacOS / IOS.
 -   [PsTube](https://github.com/prateekmedia/pstube) - Watch and download videos without ads on Android, Linux, Windows, iOS, and Mac OSX.
 -   [Harmony Music](https://github.com/anandnet/Harmony-Music) - YouTube Music alternative for Android, built with Flutter that supports piped linking for playlists.
 -   [vidyodl](https://github.com/MrKovar/vidyodl) - A simple API to download videos from YouTube, using Piped.
--   [conduit](https://github.com/ai25/conduit) - An alternative frontend for YouTube, with a modern player and watch together capablities.
+
 
 **Web apps**
 -   [Piped-Material](https://github.com/mmjee/Piped-Material) - A fork of Piped, focusing on better performance and a more usable design.
--   [ReacTube](https://github.com/NeeRaj-2401/ReacTube) - Privacy friendly & distraction free Youtube front-end using Piped API.
--   [DeskVideo](https://github.com/malisipi/DeskVideo) - A desktop styled, customizable alternative front-end for YouTube.
 -   [Hyperpipe](https://codeberg.org/Hyperpipe/Hyperpipe) - an alternative privacy respecting front-end for YouTube Music.
+-   [ytify](https://github.com/n-ce/ytify) - a complementary audio streaming frontend for YouTube & YouTube Music.
 -   [Musicale](https://github.com/Bellisario/musicale) - an alternative frontend for YouTube Music with style.
--   [ytify](https://github.com/n-ce/ytify) - a complementary minimal audio streaming online frontend for YouTube.
+-   [conduit](https://github.com/ai25/conduit) - An alternative frontend for YouTube, with a modern player and watch together capablities.
+-   [DeskVideo](https://github.com/malisipi/DeskVideo) - A desktop styled, customizable alternative frontend for YouTube.
+-   [ReacTube](https://github.com/NeeRaj-2401/ReacTube) - Privacy friendly & distraction free YouTube frontend.
 
 ## YourKit
 


### PR DESCRIPTION
- Fix readme typo.
- Sorted `#MadeWithPiped > web apps` by relevance.
- Move conduit from desktop/mobile to web app.