### PR TITLE
fix: API retrieved playlists not shown in watch video page

### DIFF
--- a/src/components/PlaylistPage.vue
+++ b/src/components/PlaylistPage.vue
@@ -102,16 +102,8 @@ export default {
         window.removeEventListener("scroll", this.handleScroll);
     },
     methods: {
-        async fetchPlaylist() {
-            const playlistId = this.$route.query.list;
-            if (playlistId.startsWith("local")) {
-                return this.getPlaylist(playlistId);
-            }
-
-            return await await this.fetchJson(this.authApiUrl() + "/playlists/" + this.$route.query.list);
-        },
         async getPlaylistData() {
-            this.fetchPlaylist()
+            this.getPlaylist(this.$route.query.list)
                 .then(data => (this.playlist = data))
                 .then(() => {
                     this.updateTitle();

--- a/src/main.js
+++ b/src/main.js
@@ -359,7 +359,7 @@ const mixin = {
             });
         },
         async getPlaylist(playlistId) {
-            if (!this.authenticated) {
+            if (playlistId.startsWith("local")) {
                 const playlist = await this.getLocalPlaylist(playlistId);
                 const videoIds = JSON.parse(playlist.videoIds);
                 const videosFuture = videoIds.map(videoId => this.getLocalPlaylistVideo(videoId));


### PR DESCRIPTION
My previous PR (#3357), although it fixed local playlists being shown in the watch page, it apparently broke API retrieved playlists (both YouTube playlists as well as those saved on instances when authenticated), hence this PR that aims to fix both - hopefully without introducing other bugs along the way, like my last PR 😅
