### PR TITLE
feat: make `ConfirmModal` emit `"confirm"` if Enter is pressed

### DIFF
--- a/src/components/ConfirmModal.vue
+++ b/src/components/ConfirmModal.vue
@@ -24,5 +24,19 @@ export default {
         },
     },
     emits: ["close", "confirm"],
+    mounted() {
+        window.addEventListener("keydown", this.handleKeyDown);
+    },
+    unmounted() {
+        window.removeEventListener("keydown", this.handleKeyDown);
+    },
+    methods: {
+        handleKeyDown(event) {
+            if (event.code === "Enter") {
+                this.$emit("confirm");
+                event.preventDefault();
+            }
+        },
+    },
 };
 </script>


### PR DESCRIPTION
Hello.  
I noticed that `PlaylistAddModal` adds a video to a playlist if Enter is pressed, but when removing a video from a playlist pressing Enter does not do anything.  
"Remove video from playlist" modal is implemented with `ConfirmModal`, so I made `ConfirmModal` emit `"confirm"` if Enter is pressed to mirror `PlaylistAddModal`'s behavior.  

Since `ConfirmModal` was modified directly, other modals that use it will be affected.  
Modals affected are:
- Remove video from playlist
- Delete Playlist
- Reset preferences
- Email set as username warning when registering

I tested affected modals and I did not find bugs.

> Why should this be merged?

This change should be merged because it improves keyboard accessibility.