### PR TITLE
fix: Infinite loading when search query is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pnpm install
 ### Compiles and hot-reloads for development
 
 ```
-pnpm serve
+pnpm dev
 ```
 
 You can now make changes and view then in realtime!

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -200,10 +200,14 @@ export default {
         },
         submitSearch(e) {
             e.target.blur();
-            this.$router.push({
-                name: "SearchResults",
-                query: { search_query: this.searchText },
-            });
+            if (this.searchText) {
+                this.$router.push({
+                    name: "SearchResults",
+                    query: { search_query: this.searchText },
+                });
+            } else {
+                this.$router.push("/");
+            }
             return;
         },
     },


### PR DESCRIPTION
## Bug

When search query string is empty, Piped loads infinitely. This is replicable on hosted instances such as do.piped.video and in development environment as well.

Here's a screenshot for it (note the URL bar with null search_query):

![URL bar showing empty search_query and the results are loaded infinitely](https://github.com/TeamPiped/Piped/assets/142780733/983779f6-2f38-43a8-bd4e-625c08e1d61f)

This is tested on

1. Chromium 121
2. Firefox 122

as well.

This PR aims to redirect users to landing page when the search query is empty (I am entirely not sure if a toast need to be showed for this to the user), and display results only when search query is non-null.