### PR TITLE
feat: support for subscription imports from FreeTube

### DIFF
--- a/src/components/ImportPage.vue
+++ b/src/components/ImportPage.vue
@@ -88,10 +88,11 @@ export default {
                     });
                 }
                 // NewPipe
-                else if (text.indexOf("app_version") != -1) {
+                else if (text.indexOf("subscriptions") != -1) {
                     const json = JSON.parse(text);
                     json.subscriptions
-                        .filter(item => item.service_id == 0)
+                        // if service_id is undefined, chances are it's a freetube export
+                        .filter(item => item.service_id == 0 || item.service_id == undefined)
                         .forEach(item => {
                             const url = item.url;
                             const id = url.slice(-24);

--- a/src/components/ImportPage.vue
+++ b/src/components/ImportPage.vue
@@ -99,14 +99,6 @@ export default {
                             this.subscriptions.push(id);
                         });
                 }
-                // Libretube
-                else if (text.includes("localSubscriptions")) {
-                    const json = JSON.parse(text);
-                    json.localSubscriptions
-                        .forEach(item => {
-                            this.subscriptions.push(item.channelId);
-                        });
-                }
                 // Invidious JSON
                 else if (text.indexOf("thin_mode") != -1) {
                     const json = JSON.parse(text);

--- a/src/components/ImportPage.vue
+++ b/src/components/ImportPage.vue
@@ -99,6 +99,14 @@ export default {
                             this.subscriptions.push(id);
                         });
                 }
+                // Libretube
+                else if (text.indexOf("localSubscriptions") != -1) {
+                    const json = JSON.parse(text);
+                    json.localSubscriptions
+                        .forEach(item => {
+                            this.subscriptions.push(item.channelId);
+                        });
+                }
                 // Invidious JSON
                 else if (text.indexOf("thin_mode") != -1) {
                     const json = JSON.parse(text);

--- a/src/components/ImportPage.vue
+++ b/src/components/ImportPage.vue
@@ -100,7 +100,7 @@ export default {
                         });
                 }
                 // Libretube
-                else if (text.indexOf("localSubscriptions") != -1) {
+                else if (text.includes("localSubscriptions")) {
                     const json = JSON.parse(text);
                     json.localSubscriptions
                         .forEach(item => {


### PR DESCRIPTION
Made a quick patch so that you could import libretubes version of (NewPipe & FreeTube) subscription exports and import from libretube backup files.
Examples of which:

Libretube backup:
```json
{
    "localSubscriptions": [
        {
            "channelId": "UCfFstf5a-EbrCZsaBHj_b7A"
        },
        {
            "channelId": "UC-KGsbXtpu1DyscyNznxpLA"
        }
    ]
}
```
freetube:
```json
{
    "subscriptions": [
        {
            "name": "Dean Herbert",
            "id": "",
            "url": "https://www.youtube.com/channel/UCfFstf5a-EbrCZsaBHj_b7A"
        },
        {
            "name": "4096",
            "id": "",
            "url": "https://www.youtube.com/channel/UCTH6s1SMIQicvyd8OLBYMtQ"
        }
    ]
}
```
NewPipe:
```json
{
    "subscriptions": [
        {
            "name": "Dean Herbert",
            "service_id": 0,
            "url": "https://www.youtube.com/channel/UCfFstf5a-EbrCZsaBHj_b7A"
        },
        {
            "name": "4096",
            "service_id": 0,
            "url": "https://www.youtube.com/channel/UCTH6s1SMIQicvyd8OLBYMtQ"
        }
    ]
}
```