### PR TITLE
EFY Lang Path - Potential Temporary Fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -58,8 +58,8 @@ import router from "@/router/router.js";
 import "uno.css";
 
 /*EFY UI*/
-// import "../node_modules/efy/efy.css";
 import "efy/efy.css";
+import "efy/lang/en.css"; // temporary translation fix
 import "./piped.css";
 import "efy/efy.js";
 import "./piped.js";


### PR DESCRIPTION
Seems to work fine while building and serving but not on the actual live instance, so maybe adding it from the `main.js` file as a backup can help, while we figure out the right path