### PR TITLE
feat: support for albums channel tab

### DIFF
--- a/src/components/ChannelPage.vue
+++ b/src/components/ChannelPage.vue
@@ -213,8 +213,8 @@ export default {
                 case "playlists":
                     translatedTabName = this.$t("titles.playlists");
                     break;
-                case "channels":
-                    translatedTabName = this.$t("titles.channels");
+                case "albums":
+                    translatedTabName = this.$t("titles.albums");
                     break;
                 case "shorts":
                     translatedTabName = this.$t("video.shorts");

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,6 +13,7 @@
         "player": "Player",
         "livestreams": "Livestreams",
         "channels": "Channels",
+        "albums": "Albums",
         "bookmarks": "Bookmarks",
         "channel_groups": "Channel groups",
         "dearrow": "DeArrow"


### PR DESCRIPTION
depends on https://github.com/TeamPiped/Piped-Backend/pull/778

The channels tab was removed from YouTube.