### PR TITLE
feat: make `CreatePlaylistmodal` handle `Enter` key and auto focus input, `PlaylistAddModal` switches to created playlist

### DIFF
--- a/src/components/CreatePlaylistModal.vue
+++ b/src/components/CreatePlaylistModal.vue
@@ -24,7 +24,19 @@ export default {
             playlistName: "",
         };
     },
+    mounted() {
+        window.addEventListener("keydown", this.handleKeyDown);
+    },
+    unmounted() {
+        window.removeEventListener("keydown", this.handleKeyDown);
+    },
     methods: {
+        handleKeyDown(event) {
+            if (event.code === "Enter") {
+                this.onCreatePlaylist();
+                event.preventDefault();
+            }
+        },
         onCreatePlaylist() {
             if (!this.playlistName) return;
 

--- a/src/components/CreatePlaylistModal.vue
+++ b/src/components/CreatePlaylistModal.vue
@@ -43,7 +43,7 @@ export default {
             this.createPlaylist(this.playlistName).then(response => {
                 if (response.error) alert(response.error);
                 else {
-                    this.$emit("created");
+                    this.$emit("created", response.playlistId, this.playlistName);
                     this.$emit("close");
                 }
             });

--- a/src/components/CreatePlaylistModal.vue
+++ b/src/components/CreatePlaylistModal.vue
@@ -2,7 +2,7 @@
     <ModalComponent @close="$emit('close')">
         <div class="flex flex-col">
             <h2 v-t="'actions.create_playlist'" />
-            <input v-model="playlistName" type="text" class="input mt-2" />
+            <input ref="input" v-model="playlistName" type="text" class="input mt-2" />
             <div class="ml-auto mt-3 w-min flex">
                 <button v-t="'actions.cancel'" class="btn" @click="$emit('close')" />
                 <button v-t="'actions.okay'" class="btn ml-2" @click="onCreatePlaylist" />
@@ -25,6 +25,7 @@ export default {
         };
     },
     mounted() {
+        this.$refs.input.focus();
         window.addEventListener("keydown", this.handleKeyDown);
     },
     unmounted() {

--- a/src/components/PlaylistAddModal.vue
+++ b/src/components/PlaylistAddModal.vue
@@ -65,7 +65,7 @@ export default {
     },
     methods: {
         handleKeyDown(event) {
-            if (event.code === "Enter") {
+            if (event.code === "Enter" && !this.showCreatePlaylistModal) {
                 this.handleClick(this.selectedPlaylist);
                 event.preventDefault();
             }

--- a/src/components/PlaylistAddModal.vue
+++ b/src/components/PlaylistAddModal.vue
@@ -22,7 +22,7 @@
     <CreatePlaylistModal
         v-if="showCreatePlaylistModal"
         @close="showCreatePlaylistModal = false"
-        @created="fetchPlaylists"
+        @created="addCreatedPlaylist"
     />
 </template>
 
@@ -55,7 +55,9 @@ export default {
         };
     },
     mounted() {
-        this.fetchPlaylists();
+        this.getPlaylists().then(json => {
+            this.playlists = json;
+        });
         this.selectedPlaylist = this.getPreferenceString("selectedPlaylist" + this.hashCode(this.authApiUrl()));
         window.addEventListener("keydown", this.handleKeyDown);
         window.blur();
@@ -87,10 +89,9 @@ export default {
                 if (json.error) alert(json.error);
             });
         },
-        async fetchPlaylists() {
-            this.getPlaylists().then(json => {
-                this.playlists = json;
-            });
+        addCreatedPlaylist(playlistId, playlistName) {
+            this.playlists.push({ id: playlistId, name: playlistName });
+            this.selectedPlaylist = playlistId;
         },
     },
 };


### PR DESCRIPTION
Hello.
This pull request has 4 changes:
- `CreatePlaylistModal` now handles `Enter` properly (creates the playlist and emits `"close"`)
- `PlaylistAddModal` used to add the video to playlist and close itself when pressing `Enter` while creating a playlist, this is fixed now
- `PlaylistAddModal` now switches to the created playlist
- while I was at it, I made `CreatePlaylistModal`'s input focus when mounted

It doesn't look like there is auto focus for inputs anywhere on the website, is this by design? aka should I revert the last commit?

The changes are broken into their own commits in the same order.