### PR TITLE
fix: update text in search field when clicking on suggestion

### DIFF
--- a/src/components/SearchSuggestions.vue
+++ b/src/components/SearchSuggestions.vue
@@ -73,9 +73,6 @@ export default {
                 this.selected = i;
             }
         },
-        onClick(i) {
-            this.setSelected(i);
-        },
         setSelected(val) {
             this.selected = val;
             this.$emit("searchchange", this.searchSuggestions[this.selected]);

--- a/src/components/SearchSuggestions.vue
+++ b/src/components/SearchSuggestions.vue
@@ -1,7 +1,12 @@
 <template>
     <div class="suggestions-container absolute">
         <ul>
-            <li v-for="(suggestion, i) in searchSuggestions" :key="i" @mouseover="onMouseOver(i)">
+            <li
+                v-for="(suggestion, i) in searchSuggestions"
+                :key="i"
+                @mouseover="onMouseOver(i)"
+                @click="setSelected(i)"
+            >
                 <router-link
                     class="suggestion"
                     :class="{ 'suggestion-selected': selected === i }"


### PR DESCRIPTION
Currently, the text in the search field only updates itself when you select a suggestion via the up/down arrow keys, but _not_ when clicking on a suggestion with the left mouse button. However, the `h1` element below the input field changes in both cases. I personally find this quite irritating.

It seems like this is unintended behavior: There is a function named `onClick(i)` which does exactly the thing I would like to have, but apparently it is never called anywhere.

Thanks in advance for your answer!