### PR TITLE
fix: listen/watch icon in VideoItem.vue

### DIFF
--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -106,7 +106,7 @@
                     :aria-label="preferListen ? title : 'Listen to ' + title"
                     :title="preferListen ? title : 'Listen to ' + title"
                 >
-                    <font-awesome-icon :icon="preferListen ? 'i-fa6-solid:tv' : 'i-fa6-solid:headphones'" />
+                    <i :class="preferListen ? 'i-fa6-solid:tv' : 'i-fa6-solid:headphones'" />
                 </router-link>
                 <button :title="$t('actions.add_to_playlist')" @click="showPlaylistModal = !showPlaylistModal">
                     <i class="i-fa6-solid:circle-plus" />


### PR DESCRIPTION
I am so sorry I didn't test my last PR thoroughly after resolving the conflict with master.
Now the icons for listen / watch are gone on every video-item.

This PR fixes my mistake.