### PR TITLE
feat: eslint rule vue/no-undef-components makes build fail

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,4 +4,9 @@ module.exports = {
         node: true,
     },
     extends: ["plugin:vue/vue3-recommended", "eslint:recommended", "@unocss", "plugin:prettier/recommended"],
+    rules: {
+        "vue/no-undef-components": ["error", {
+            ignorePatterns: ["router-link", "router-view", "i18n-t", "ErrorHandler"]
+        }],
+    },
 };

--- a/src/components/CommentItem.vue
+++ b/src/components/CommentItem.vue
@@ -50,6 +50,7 @@
             </template>
             <div v-show="showingReplies" v-if="replies" class="replies">
                 <div v-for="reply in replies" :key="reply.commentId" class="w-full">
+                    <!-- eslint-disable-next-line vue/no-undef-components -->
                     <CommentItem :comment="reply" :uploader="uploader" :video-id="videoId" />
                 </div>
                 <div v-if="nextpage" class="cursor-pointer" @click="loadReplies">


### PR DESCRIPTION
To prevent mistakes like in #3490, I made the checking of eslint more strict.

Feel free to suggest more I should try to apply.