### PR TITLE
chore(readme): add PlasmaTube for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,10 @@ Contributions in any other form are also welcomed.
 # Made with Piped
 
 **Mobile/desktop apps**
--   [LibreTube](https://github.com/Libre-tube/LibreTube) - Alternative frontend for YouTube, for Android.
+-   [LibreTube](https://github.com/Libre-tube/LibreTube) - Alternative frontend for YouTube for Android.
 -   [YTDLnis](https://github.com/deniscerri/ytdlnis) - Video and audio downloader for Android that uses Piped to update formats.
--   [Yattee](https://github.com/yattee/yattee) - Alternative frontend for YouTube, for MacOS / IOS.
+-   [Yattee](https://github.com/yattee/yattee) - Alternative frontend for YouTube for MacOS / iOS.
+-   [PlasmaTube](https://apps.kde.org/plasmatube/) - Alternative frontend for YouTube for Linux.
 -   [PsTube](https://github.com/prateekmedia/pstube) - Watch and download videos without ads on Android, Linux, Windows, iOS, and Mac OSX.
 -   [Harmony Music](https://github.com/anandnet/Harmony-Music) - YouTube Music alternative for Android, built with Flutter that supports piped linking for playlists.
 -   [VibeYou](https://github.com/you-apps/VibeYou) - Privacy focused music player for Android supporting playback via Piped.


### PR DESCRIPTION
PlasmaTube 24.02.1 for Linux is now available from flathub. https://flathub.org/apps/org.kde.plasmatube (At the time previously mentioned there was no Piped feature: https://github.com/TeamPiped/Piped/pull/3174#issuecomment-1836225682)

It's still experimental. Search in Piped is not working. To watch the video, you must press the play button. There is no login feature to Piped. But it may be implemented. because Invidious can log in.