### PR TITLE
feat: keep the last 5 minutes of buffer

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -364,6 +364,7 @@ export default {
                         "streaming.bufferingGoal",
                         Math.max(this.getPreferenceNumber("bufferGoal", 10), 10),
                     );
+                    localPlayer.configure("streaming.bufferBehind", 300);
 
                     this.setPlayerAttrs(localPlayer, videoEl, uri, mime, this.$shaka);
                 });


### PR DESCRIPTION
since buffering can take a long time on piped, this will make it less likely to have to reset the whole buffer if you skip backwards