### PR TITLE
Update search text and title when route changes

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -152,14 +152,22 @@ export default {
             return _this.getPreferenceBoolean("searchHistory", false) && localStorage.getItem("search_history");
         },
     },
+    watch: {
+        $route() {
+            this.updateSearchTextFromURLSearchParams();
+        },
+    },
     mounted() {
         this.fetchAuthConfig();
-        const query = new URLSearchParams(window.location.search).get("search_query");
-        if (query) this.onSearchTextChange(query);
+        this.updateSearchTextFromURLSearchParams();
         this.focusOnSearchBar();
         this.homePagePath = this.getHomePage(this);
     },
     methods: {
+        updateSearchTextFromURLSearchParams() {
+            const query = new URLSearchParams(window.location.search).get("search_query");
+            if (query) this.onSearchTextChange(query);
+        },
         // focus on search bar when Ctrl+k is pressed
         focusOnSearchBar() {
             hotkeys("ctrl+k", event => {

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -56,6 +56,11 @@ export default {
         this.updateResults();
         this.saveQueryToHistory();
     },
+    updated() {
+        if (this.$route.query.search_query !== undefined) {
+            document.title = this.$route.query.search_query + " - Piped";
+        }
+    },
     activated() {
         this.handleRedirect();
         window.addEventListener("scroll", this.handleScroll);


### PR DESCRIPTION
Previously, only the `h1` below the search field updated when going back and forth in the browsing history. With this change, the title displayed in the tab and the text in the search field update as well, see the attached screen cast.

https://github.com/user-attachments/assets/d51bded1-447a-4688-9565-d9b662781a34
