### PR TITLE
feat: Mark as Watched in feed

### DIFF
--- a/src/components/FeedPage.vue
+++ b/src/components/FeedPage.vue
@@ -48,7 +48,7 @@
 
     <LoadingIndicatorPage :show-content="videosStore != null" class="video-grid">
         <template v-for="video in filteredVideos" :key="video.url">
-            <VideoItem v-if="shouldShowVideo(video)" :is-feed="true" :item="video" />
+            <VideoItem v-if="shouldShowVideo(video)" :is-feed="true" :item="video" @update:watched="onUpdateWatched" />
         </template>
     </LoadingIndicatorPage>
 </template>
@@ -139,6 +139,15 @@ export default {
             if (window.innerHeight + window.scrollY >= document.body.offsetHeight - window.innerHeight) {
                 this.loadMoreVideos();
             }
+        },
+        onUpdateWatched(urls = null) {
+            if (urls === null) {
+                if (this.videos.length > 0) this.updateWatched(this.videos);
+                return;
+            }
+
+            const subset = this.videos.filter(({ url }) => urls.includes(url));
+            if (subset.length > 0) this.updateWatched(subset);
         },
         shouldShowVideo(video) {
             switch (this.selectedFilter.toLowerCase()) {

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -127,7 +127,11 @@
                     ref="watchButton"
                     @click="toggleWatched(item.url.substr(-11))"
                 >
-                    <i v-if="item.watched" :title="$t('actions.mark_as_unwatched')" class="i-fa6-solid:eye-slash" />
+                    <i
+                        v-if="item.watched && item.currentTime > item.duration * 0.9"
+                        :title="$t('actions.mark_as_unwatched')"
+                        class="i-fa6-solid:eye-slash"
+                    />
                     <i v-else :title="$t('actions.mark_as_watched')" class="i-fa6-solid:eye" />
                 </button>
                 <ConfirmModal
@@ -247,7 +251,7 @@ export default {
                         };
                     }
                     video.currentTime =
-                        instance.item.currentTime !== instance.item.duration ? instance.item.duration : 0;
+                        instance.item.currentTime < instance.item.duration * 0.9 ? instance.item.duration : 0;
                     store.put(video);
                     instance.$emit("update:watched", [instance.item.url]);
                     instance.shouldShowVideo();

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -242,7 +242,7 @@ export default {
                             videoId: videoId,
                             title: instance.item.title,
                             duration: instance.item.duration,
-                            thumbnail: instance.item.thumbnailUrl,
+                            thumbnail: instance.item.thumbnail,
                             uploaderUrl: instance.item.uploaderUrl,
                             uploaderName: instance.item.uploader,
                             watchedAt: Date.now(),

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -122,8 +122,11 @@
                 >
                     <i class="i-fa6-solid:circle-minus" />
                 </button>
-                <!-- TODO hide watchButton if history is disabled -->
-                <button ref="watchButton" @click="toggleWatched(item.url.substr(-11))">
+                <button
+                    v-if="showMarkOnWatched && isFeed"
+                    ref="watchButton"
+                    @click="toggleWatched(item.url.substr(-11))"
+                >
                     <i v-if="item.watched" :title="$t('actions.mark_as_unwatched')" class="i-fa6-solid:eye-slash" />
                     <i v-else :title="$t('actions.mark_as_watched')" class="i-fa6-solid:eye" />
                 </button>
@@ -183,6 +186,7 @@ export default {
             showShareModal: false,
             showVideo: true,
             showConfirmRemove: false,
+            showMarkOnWatched: false,
         };
     },
     computed: {
@@ -195,6 +199,7 @@ export default {
     },
     mounted() {
         this.shouldShowVideo();
+        this.shouldShowMarkOnWatched();
     },
     methods: {
         removeVideo() {
@@ -216,6 +221,9 @@ export default {
                     return;
                 }
             };
+        },
+        shouldShowMarkOnWatched() {
+            this.showMarkOnWatched = this.getPreferenceBoolean("watchHistory", false);
         },
         toggleWatched(videoId) {
             if (window.db) {

--- a/src/components/VideoItem.vue
+++ b/src/components/VideoItem.vue
@@ -227,7 +227,6 @@ export default {
         },
         toggleWatched(videoId) {
             if (window.db) {
-                // Should match WatchVideo.vue
                 var tx = window.db.transaction("watch_history", "readwrite");
                 var store = tx.objectStore("watch_history");
                 var instance = this;
@@ -237,23 +236,19 @@ export default {
                     if (video) {
                         video.watchedAt = Date.now();
                     } else {
-                        // Should match WatchVideo.vue
                         video = {
                             videoId: videoId,
                             title: instance.item.title,
                             duration: instance.item.duration,
                             thumbnail: instance.item.thumbnail,
                             uploaderUrl: instance.item.uploaderUrl,
-                            uploaderName: instance.item.uploader,
+                            uploaderName: instance.item.uploaderName,
                             watchedAt: Date.now(),
                         };
                     }
-                    // Set time to end for shouldShowVideo
                     video.currentTime =
                         instance.item.currentTime !== instance.item.duration ? instance.item.duration : 0;
-                    // Save
                     store.put(video);
-                    // Disappear if hideWatched is on
                     instance.$emit("update:watched", [instance.item.url]);
                     instance.shouldShowVideo();
                 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -132,6 +132,8 @@
         "show_chapters": "Chapters",
         "store_search_history": "Store Search History",
         "hide_watched": "Hide watched videos in the feed",
+        "mark_as_watched": "Mark as Watched",
+        "mark_as_unwatched": "Mark as Unwatched",
         "documentation": "Documentation",
         "status_page": "Status",
         "source_code": "Source code",

--- a/src/main.js
+++ b/src/main.js
@@ -144,6 +144,11 @@ const mixin = {
                     var request = store.get(video.url.substr(-11));
                     request.onsuccess = function (event) {
                         if (event.target.result) {
+                            if (event.target.result.currentTime == 0) {
+                                video.watched = false;
+                                video.currentTime = event.target.result.currentTime;
+                                return;
+                            }
                             video.watched = true;
                             video.currentTime = event.target.result.currentTime;
                         }

--- a/src/main.js
+++ b/src/main.js
@@ -144,12 +144,7 @@ const mixin = {
                     var request = store.get(video.url.substr(-11));
                     request.onsuccess = function (event) {
                         if (event.target.result) {
-                            if (event.target.result.currentTime == 0) {
-                                video.watched = false;
-                                video.currentTime = event.target.result.currentTime;
-                                return;
-                            }
-                            video.watched = true;
+                            video.watched = event.target.result.currentTime != 0;
                             video.currentTime = event.target.result.currentTime;
                         }
                     };


### PR DESCRIPTION
This PR builds upon crhallberg's PR (#1581) which add a button besides “Add to Playlist” button for videos in feed.

- The button is hidden when watch history is disabled and not viewing the feed.
- The button adds videos to the watch history and hides them from the feed, depending on preferences.
- The button resets the duration of the video if clicked after marked as watched, but does not remove it from watch history.

Addresses #1512.
Closes #1581.