### PR TITLE
fix: wrong selection of default audio language

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -613,7 +613,7 @@ export default {
                         // Set the audio language
                         const prefLang = this.getPreferenceString("hl", "en").substr(0, 2);
                         var lang = "en";
-                        for (var l in player.getAudioLanguages()) {
+                        for (var l of player.getAudioLanguages()) {
                             if (l == prefLang) {
                                 lang = l;
                                 return;


### PR DESCRIPTION
It would always fallback to `en` as the loop was over array keys, not values.
_I don't know much about JS but this `for..of` works in Firefox. Apparently it is ES6 compliant, supported pretty much everywhere except IE11_

**Really needed now that many English tracks of non-English videos are AI translated _(because yt enabled it by default)_ 🤢**

Notes:

- Ideally it would be great to be able to detect AI translated tracks, or "original language", not sure if it's possible with current extractor _(or with yt in general)_ EDIT: Apparently it is, and it's already included in proxy's response, nice!
- And also have a separate setting for Audio language (right now it's the same as UI language, which isn't so great) 

EDIT: I've added this to a related open feature request https://github.com/TeamPiped/Piped/issues/2240#issuecomment-2543971520