### PR TITLE
Add playsinline attribute to video tag

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -5,7 +5,7 @@
         class="relative max-h-screen w-full flex justify-center"
         :class="{ 'player-container': !isEmbed }"
     >
-        <video ref="videoEl" class="w-full" data-shaka-player :autoplay="shouldAutoPlay" :loop="selectedAutoLoop" />
+        <video ref="videoEl" class="w-full" data-shaka-player :autoplay="shouldAutoPlay" :loop="selectedAutoLoop" playsinline />
         <span
             id="preview-container"
             ref="previewContainer"


### PR DESCRIPTION
This PR fixes #3734 by adding the playsinline attribute to the video tag in VideoPlayer.vue.

This attribute is required for iOS devices to play videos inline instead of going into fullscreen mode by default.