### PR TITLE
Make list styling consistent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,11 @@ Contributions in any other form are also welcomed.
 
 
 **Not Under Active Development**
-  
 -   [PsTube](https://github.com/prateekmedia/pstube) - Watch and download videos without ads on Android, Linux, Windows, iOS, and Mac OSX.
--   [VibeYou](https://github.com/you-apps/VibeYou) - Privacy focused music player for Android supporting playback via Piped.
-  
+-   [VibeYou](https://github.com/you-apps/VibeYou) - Privacy focused music player for Android supporting playback via Piped. 
 -   [conduit](https://github.com/ai25/conduit) - Alternative frontend for YouTube, with a modern player and watch together capabilities.
 -   [DeskVideo](https://github.com/malisipi/DeskVideo) - Desktop styled, customizable alternative frontend for YouTube.
 -   [ReacTube](https://github.com/NeeRaj-2401/ReacTube) - Privacy friendly & distraction free YouTube frontend.
-
 -   [vidyodl](https://github.com/MrKovar/vidyodl) - Simple API to download videos from YouTube, using Piped.
 -   [Piped Addon for Kodi](https://github.com/syhlx/plugin.video.piped) - Kodi plugin for Piped.
 


### PR DESCRIPTION
When looking through the README i noticed this odd spacing in the Not Under Active Development list compared to the other lists.
The reason for this is that its being grouped by category in the code but that cant be reflected visually. 

![firefox_8quGYRdDRk](https://github.com/user-attachments/assets/df17893f-feb1-4728-a376-2f1df7a6ea2d)

So you can do 2 things:
- Split up the lists like its done here: https://github.com/TeamPiped/Piped/blob/master/README.md?plain=1#L138-L151
- Make one big list

I chose the latter one as i dont think its important here to categorize applications that arent under active development

Before:

![l9TuScmORm](https://github.com/user-attachments/assets/94bd9ac1-fa86-40e3-9ae2-be1444a06262)

After:

![firefox_8Ya9ueDbi0](https://github.com/user-attachments/assets/4a7fd831-c30f-47c5-a535-0857abf4ac12)
