### PR TITLE
fix: default preferHls to true on Safari

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -587,6 +587,7 @@ async function loadVideo() {
     streams.push(...props.video.videoStreams);
 
     const MseSupport = window.MediaSource !== undefined || window.ManagedMediaSource !== undefined;
+    // Safari has limited MSE/DASH support, so we default to native HLS playback.
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
     const lbry = null;
@@ -639,6 +640,7 @@ async function loadVideo() {
             return response.headers.get("Content-Type");
         });
         mime = contentType;
+    // Safari defaults to HLS due to limited MSE/DASH support (see isSafari above).
     } else if (props.video.dash && !getPreferenceBoolean("preferHls", isSafari)) {
         uri = props.video.dash;
         mime = "application/dash+xml";

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -640,7 +640,7 @@ async function loadVideo() {
             return response.headers.get("Content-Type");
         });
         mime = contentType;
-    // Safari defaults to HLS due to limited MSE/DASH support (see isSafari above).
+        // Safari defaults to HLS due to limited MSE/DASH support (see isSafari above).
     } else if (props.video.dash && !getPreferenceBoolean("preferHls", isSafari)) {
         uri = props.video.dash;
         mime = "application/dash+xml";

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -587,6 +587,7 @@ async function loadVideo() {
     streams.push(...props.video.videoStreams);
 
     const MseSupport = window.MediaSource !== undefined || window.ManagedMediaSource !== undefined;
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
     const lbry = null;
 
@@ -600,7 +601,7 @@ async function loadVideo() {
         props.video.audioStreams.length > 0 &&
         !lbry &&
         MseSupport &&
-        !getPreferenceBoolean("preferHls", false)
+        !getPreferenceBoolean("preferHls", isSafari)
     ) {
         if (!props.video.dash) {
             const dash = (await import("../utils/DashUtils.js")).generate_dash_file_from_formats(
@@ -638,7 +639,7 @@ async function loadVideo() {
             return response.headers.get("Content-Type");
         });
         mime = contentType;
-    } else if (props.video.dash && !getPreferenceBoolean("preferHls", false)) {
+    } else if (props.video.dash && !getPreferenceBoolean("preferHls", isSafari)) {
         uri = props.video.dash;
         mime = "application/dash+xml";
     } else if (props.video.hls) {


### PR DESCRIPTION
## Problem

Safari users get error 3016 (Shaka Player `VIDEO_ERROR` / `PIPELINE_ERROR_DECODE`) when playing videos. This happens because:

1. YouTube no longer provides HLS/DASH manifest URLs (both are `null` in the API response)
2. The frontend generates a DASH manifest from individual streams
3. Safari's MSE implementation has poor DASH support, causing playback to fail

## Fix

Detect Safari via user agent and default `preferHls` to `true` instead of `false`. This makes Safari use HLS (which it supports natively) by default, while keeping DASH as the default for Chrome/Firefox where MSE works well.

Users can still override this in Preferences.

## Testing

- Safari 26.3 on macOS: videos now play without error
- Chrome/Firefox: behavior unchanged (still uses DASH by default)
- The preference toggle still works to override the default in either direction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced video streaming compatibility by improving stream format selection to account for browser-specific media support limitations, particularly benefiting Safari users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeamPiped/Piped/pull/4236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->