### PR TITLE
Firefox fixes: slow video loading and video player highlight 

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -972,4 +972,16 @@ defineExpose({
         max-width: none !important;
     }
 }
+
+/* Suppress Firefox/Gecko's blue :focus outline on the <video> element.
+   We explicitly .focus() the video on seek-bar mouseup (so hotkeys-js keeps
+   receiving keys), and Gecko draws a system focus outline whenever a <video>
+   is focused. Chromium uses :focus-visible heuristics on media elements so it
+   doesn't render the outline for click-driven focus. Kept outside @layer so
+   it wins over any layered rule, and !important to override the UA focus ring
+   if specificity gets shadowed. */
+video.shaka-video:focus,
+video[data-shaka-player]:focus {
+    outline: none !important;
+}
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+import "@/utils/firefoxMediaCapabilitiesFix.js";
 import { createApp } from "vue";
 import router from "@/router/router.js";
 import App from "./App.vue";

--- a/src/utils/firefoxMediaCapabilitiesFix.js
+++ b/src/utils/firefoxMediaCapabilitiesFix.js
@@ -1,0 +1,49 @@
+/**
+ * Workaround for shaka-project/shaka-player#4775.
+ *
+ * Firefox's navigator.mediaCapabilities.decodingInfo() costs ~14 ms per call
+ * (out-of-process decoder probe). Shaka calls it once per Variant in the DASH
+ * manifest while filtering supported variants; YouTube manifests routinely
+ * have 1000+ variants, so player initialization stalls 15-20 s on Gecko-based
+ * browsers before any SourceBuffer is added or any segment is fetched.
+ *
+ * This module delegates the "supported" check to MediaSource.isTypeSupported
+ * (sub-ms on Firefox) and caches the result per MIME string. Smooth /
+ * powerEfficient are returned conservatively as true; Shaka's ABR will
+ * downshift if real playback isn't smooth.
+ *
+ * Active only on Gecko engines, so Chromium / Safari / Edge / iOS Firefox
+ * (WebKit) are unaffected. DRM probes (keySystemConfiguration) and non-
+ * media-source query types fall through to the native API unchanged.
+ *
+ * Remove this module (and its import in main.js) once Shaka ships a caching
+ * fix for #4775.
+ */
+if (
+    typeof navigator !== "undefined" &&
+    /Gecko\/[0-9]/.test(navigator.userAgent) &&
+    navigator.mediaCapabilities &&
+    typeof navigator.mediaCapabilities.decodingInfo === "function"
+) {
+    const orig = navigator.mediaCapabilities.decodingInfo.bind(navigator.mediaCapabilities);
+    const cache = new Map();
+    const mimeOk = mime => {
+        if (!cache.has(mime)) cache.set(mime, MediaSource.isTypeSupported(mime));
+        return cache.get(mime);
+    };
+    navigator.mediaCapabilities.decodingInfo = function (config) {
+        if (config && config.type === "media-source" && !config.keySystemConfiguration) {
+            const v = config.video;
+            const a = config.audio;
+            const supported = (!v || mimeOk(v.contentType)) && (!a || mimeOk(a.contentType));
+            return Promise.resolve({
+                supported,
+                smooth: supported,
+                powerEfficient: supported,
+                keySystemAccess: null,
+                configuration: config,
+            });
+        }
+        return orig(config);
+    };
+}

--- a/src/utils/firefoxMediaCapabilitiesFix.js
+++ b/src/utils/firefoxMediaCapabilitiesFix.js
@@ -22,7 +22,9 @@
  * (WebKit) are unaffected. DRM probes (keySystemConfiguration) and non-
  * media-source query types fall through to the native API unchanged.
  *
- * Refs: https://github.com/TeamPiped/Piped/issues/4238
+ * Refs:
+ *   https://bugzilla.mozilla.org/show_bug.cgi?id=2043895
+ *   https://github.com/TeamPiped/Piped/issues/4238
  */
 if (
     typeof navigator !== "undefined" &&

--- a/src/utils/firefoxMediaCapabilitiesFix.js
+++ b/src/utils/firefoxMediaCapabilitiesFix.js
@@ -1,23 +1,28 @@
 /**
- * Workaround for shaka-project/shaka-player#4775.
+ * HACK: Firefox-only fast path for navigator.mediaCapabilities.decodingInfo().
  *
- * Firefox's navigator.mediaCapabilities.decodingInfo() costs ~14 ms per call
- * (out-of-process decoder probe). Shaka calls it once per Variant in the DASH
- * manifest while filtering supported variants; YouTube manifests routinely
- * have 1000+ variants, so player initialization stalls 15-20 s on Gecko-based
- * browsers before any SourceBuffer is added or any segment is fetched.
+ * Rough comparison: Chromium ~0.1 ms/call vs Firefox ~20 ms/call.
+ * Shaka calls decodingInfo once per Variant while filtering the manifest, so on
+ * a YouTube-shape manifest with many Variants Firefox stalls several seconds at
+ * player init before any SourceBuffer is added.
  *
- * This module delegates the "supported" check to MediaSource.isTypeSupported
- * (sub-ms on Firefox) and caches the result per MIME string. Smooth /
- * powerEfficient are returned conservatively as true; Shaka's ABR will
- * downshift if real playback isn't smooth.
+ * This module delegates "supported" to MediaSource.isTypeSupported (sub-ms on
+ * Firefox) and synthesizes smooth = powerEfficient = supported.
+ *
+ * KNOWN DOWNSIDE: by forcing smooth and powerEfficient to true we discard the
+ * native signals Shaka would otherwise see. If anything in the player chain
+ * reads those fields (e.g. preferredDecodingAttributes is set, a downstream
+ * consumer ranks variants on power efficiency, or a Shaka upgrade changes
+ * filtering), this shim will cause Shaka to pick streams the device cannot
+ * decode in real time — frame drops, software-decode CPU spikes, battery
+ * drain. Today (Shaka 5.1, Piped default config) those fields are not read
+ * and the shim is harmless; revisit on every Shaka upgrade.
  *
  * Active only on Gecko engines, so Chromium / Safari / Edge / iOS Firefox
  * (WebKit) are unaffected. DRM probes (keySystemConfiguration) and non-
  * media-source query types fall through to the native API unchanged.
  *
- * Remove this module (and its import in main.js) once Shaka ships a caching
- * fix for #4775.
+ * Refs: https://github.com/TeamPiped/Piped/issues/4238
  */
 if (
     typeof navigator !== "undefined" &&


### PR DESCRIPTION
The code was written by Claude. The code itself and the source of information were verified by me. 

### 1. decodingInfo fast-path on Firefox (a8fb96f0 + 39f201e3)

A hack to keep video loading times low (documented in the comment). We should keep an eye on this as it may cause issues for Shaka in future updates. For now it seems harmless from what I could find.

Refs: TeamPiped/Piped#4238

### 2. Suppress Firefox blue :focus outline on \<video\> (d1763ff8)

Clicking on Shaka UI elements causes the play to be highlighted. The fix is documented in its comment.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media capability detection on Firefox to provide more accurate playback support and reduce false negatives for some formats.

* **Style**
  * Removed the browser’s default focus outline on the video player for a cleaner keyboard-focus appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->