### PR TITLE
fix: use an audio element in listen mode so playback continues on iOS in the background

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -676,7 +676,7 @@ async function loadVideo() {
         uri = props.video.hls;
         mime = "application/x-mpegURL";
     } else {
-        uri = props.video.videoStreams.findLast(stream => stream.codec == null).url;
+        uri = props.video.videoStreams.findLast(stream => stream.codec == null && !stream.videoOnly).url;
         mime = "video/mp4";
     }
 

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -6,6 +6,7 @@
         :class="{ 'max-h-[75vh] min-h-64 bg-black': !isEmbed }"
     >
         <video
+            v-if="!isAudioOnly"
             ref="videoEl"
             class="w-full"
             data-shaka-player
@@ -13,6 +14,7 @@
             :loop="selectedAutoLoop"
             playsinline
         />
+        <audio v-else ref="videoEl" data-shaka-player :autoplay="shouldAutoPlay" :loop="selectedAutoLoop" />
         <button
             v-if="inSegment"
             class="skip-segment-button"
@@ -71,6 +73,7 @@ import { ref, computed, onMounted, onActivated, onDeactivated, onUnmounted } fro
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { parseTimeParam } from "@/utils/Misc";
+import { shouldUseAudioOnlyElement } from "@/utils/PlayerUtils";
 import ModalComponent from "./ModalComponent.vue";
 import {
     getPreferenceBoolean,
@@ -130,6 +133,12 @@ let thumbnailVttUrl = null;
 
 const shouldAutoPlay = computed(() => {
     return getPreferenceBoolean("playerAutoPlay", true) && !props.isEmbed;
+});
+
+// iOS only allows background/lock-screen playback for <audio> elements, not <video>
+// (even when the video track itself is disabled), so listen mode needs a real <audio> element.
+const isAudioOnly = computed(() => {
+    return shouldUseAudioOnlyElement(getPreferenceBoolean("listen", false), props.video.livestream);
 });
 
 const preferredVideoCodecs = computed(() => {
@@ -446,7 +455,7 @@ async function setPlayerAttrs(localPlayer, el, uri, mime, shaka) {
 
     playerInstance = localPlayer;
 
-    const disableVideo = getPreferenceBoolean("listen", false) && !props.video.livestream;
+    const disableVideo = isAudioOnly.value;
 
     const prefetchLimit = Math.min(Math.max(getPreferenceNumber("prefetchLimit", 2), 0), 10);
 

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -430,7 +430,9 @@ async function setPlayerAttrs(localPlayer, el, uri, mime, shaka) {
 
         uiInstance = new shaka.ui.Overlay(localPlayer, container.value, el);
 
-        const overflowMenuButtons = ["quality", "captions", "picture_in_picture", "playback_rate", "remote"];
+        const overflowMenuButtons = ["quality", "captions"];
+        if (!isAudioOnly.value) overflowMenuButtons.push("picture_in_picture");
+        overflowMenuButtons.push("playback_rate", "remote");
 
         if (props.isEmbed) {
             overflowMenuButtons.push("open_new_tab");
@@ -724,7 +726,7 @@ async function loadVideo() {
 
     if (noPrevPlayer) {
         el.addEventListener("loadeddata", () => {
-            if (document.pictureInPictureElement) el.requestPictureInPicture();
+            if (!isAudioOnly.value && document.pictureInPictureElement) el.requestPictureInPicture();
         });
         el.addEventListener("timeupdate", () => {
             const time = el.currentTime;
@@ -909,6 +911,7 @@ onActivated(() => {
                         adjustPlaybackSpeed(el.playbackRate + 0.25);
                         break;
                     case "alt+p":
+                        if (isAudioOnly.value) break;
                         document.pictureInPictureElement
                             ? document.exitPictureInPicture()
                             : el.requestPictureInPicture();

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -73,7 +73,7 @@ import { ref, computed, onMounted, onActivated, onDeactivated, onUnmounted } fro
 import { useRoute } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { parseTimeParam } from "@/utils/Misc";
-import { shouldUseAudioOnlyElement } from "@/utils/PlayerUtils";
+import { selectLegacyStream, shouldUseAudioOnlyElement } from "@/utils/PlayerUtils";
 import ModalComponent from "./ModalComponent.vue";
 import {
     getPreferenceBoolean,
@@ -676,9 +676,7 @@ async function loadVideo() {
         uri = props.video.hls;
         mime = "application/x-mpegURL";
     } else {
-        const legacyStreams = props.video.videoStreams.filter(stream => stream.codec == null);
-        const stream =
-            (isAudioOnly.value && legacyStreams.findLast(stream => !stream.videoOnly)) || legacyStreams.at(-1);
+        const stream = selectLegacyStream(props.video.videoStreams, isAudioOnly.value);
         uri = stream.url;
         mime = "video/mp4";
     }

--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -676,7 +676,10 @@ async function loadVideo() {
         uri = props.video.hls;
         mime = "application/x-mpegURL";
     } else {
-        uri = props.video.videoStreams.findLast(stream => stream.codec == null && !stream.videoOnly).url;
+        const legacyStreams = props.video.videoStreams.filter(stream => stream.codec == null);
+        const stream =
+            (isAudioOnly.value && legacyStreams.findLast(stream => !stream.videoOnly)) || legacyStreams.at(-1);
+        uri = stream.url;
         mime = "video/mp4";
     }
 

--- a/src/utils/PlayerUtils.js
+++ b/src/utils/PlayerUtils.js
@@ -1,3 +1,9 @@
 export const shouldUseAudioOnlyElement = (preferListen, isLivestream) => {
     return preferListen && !isLivestream;
 };
+
+export const selectLegacyStream = (videoStreams, isAudioOnly) => {
+    const legacyStreams = videoStreams.filter(stream => stream.codec == null);
+    const audioCapableStream = isAudioOnly && legacyStreams.findLast(stream => !stream.videoOnly);
+    return audioCapableStream || legacyStreams.at(-1);
+};

--- a/src/utils/PlayerUtils.js
+++ b/src/utils/PlayerUtils.js
@@ -1,0 +1,3 @@
+export const shouldUseAudioOnlyElement = (preferListen, isLivestream) => {
+    return preferListen && !isLivestream;
+};


### PR DESCRIPTION
Fixes #1314

## Problem

On iOS, Safari (including installed PWAs) pauses `<video>` elements as
soon as the app is backgrounded or the screen locks. Listen mode
(the headphones toggle) currently still renders a `<video>` element
and only disables the video track via `manifest.disableVideo` in the
Shaka Player config; the underlying HTML element stays `<video>`.
Since iOS keys this restriction off the element type, not whether a
video track is actually rendering, listen mode still stops playback
in the background on iOS, exactly as reported in #1314.

## Fix

When listen mode is active, the player now renders an `<audio>`
element instead of a `<video>` element. `<audio>` elements are exempt
from iOS's background-pause restriction, so playback continues
normally when the app is backgrounded or the screen locks.

The element-selection logic is extracted into a small pure function
(`shouldUseAudioOnlyElement`) so the same condition drives both the
element choice and the existing `disableVideo` config, instead of
being duplicated.

## Testing

Verified manually on iOS Safari, both as a regular tab and installed
as a PWA:
- Before this change: starting listen mode, then backgrounding the
  app or locking the screen, stops playback (reproducing #1314).
- After this change: playback continues uninterrupted in both cases.

Also verified normal (non-listen) video playback, and switching
listen mode on/off mid-playback still behave as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-only playback when “Listen” mode is selected by using an audio player.
  * Livestreams continue using video playback, even when audio-only preference is enabled.
  * Picture-in-picture controls and shortcuts are unavailable during audio-only playback.
  * Improved MP4 fallback behavior by preferring compatible audio streams in audio-only mode.
  * Ensured playback configuration stays consistent with the selected mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->